### PR TITLE
#69 filters in import flow

### DIFF
--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -230,8 +230,8 @@ class TestShortcodesSubstitution(TestCase):
         )
 
 
-class TestShortcodeHandlerRegistration(TestCase):
-    def test_included_shortcode_handlers_are_registered(self):
+class TestAbsentShortcodeHandlers(TestCase):
+    def test_included_shortcodes(self):
         # prime the SHORTCODE_HANDLERS
         # note this class has not been registered
         class FooHandler(BlockShortcodeHandler):
@@ -239,14 +239,20 @@ class TestShortcodeHandlerRegistration(TestCase):
 
         registered_handlers = SHORTCODE_HANDLERS.keys()
         self.assertIn("caption", registered_handlers)
+        self.assertNotIn("foo", registered_handlers)
 
-    def test_developer_provided_shortcode_handlers_are_registered(self):
+
+class TestIncludedShortcodeHandlers(TestCase):
+    def test_included_shortcodes(self):
+        # prime the SHORTCODE_HANDLERS
+        # note this class has been registered
         @register("foo")
         class FooHandler(BlockShortcodeHandler):
             shortcode_name = "foo"
 
         registered_handlers = SHORTCODE_HANDLERS.keys()
         self.assertIn("foo", registered_handlers)
+        self.assertIn("caption", registered_handlers)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -231,21 +231,22 @@ class TestShortcodesSubstitution(TestCase):
 
 
 class TestShortcodeHandlerRegistration(TestCase):
-    def test_caption_handlers_are_registered(self):
-        @register("caption")
-        class CaptionHandler(BlockShortcodeHandler):
-            shortcode_name = "caption"
-
-        @register("form")
-        class FormHandler(BlockShortcodeHandler):
-            shortcode_name = "form"
-
-        self.assertEqual(len(SHORTCODE_HANDLERS), 2)
+    def test_included_shortcode_handlers_are_registered(self):
+        # prime the SHORTCODE_HANDLERS
+        # note this class has not been registered
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
 
         registered_handlers = SHORTCODE_HANDLERS.keys()
-
         self.assertIn("caption", registered_handlers)
-        self.assertIn("form", registered_handlers)
+
+    def test_developer_provided_shortcode_handlers_are_registered(self):
+        @register("foo")
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        registered_handlers = SHORTCODE_HANDLERS.keys()
+        self.assertIn("foo", registered_handlers)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -231,15 +231,6 @@ class TestShortcodesSubstitution(TestCase):
 
 
 class TestShortcodeHandlerRegistration(TestCase):
-    def test_included_shortcode_handlers_are_registered(self):
-        # prime the SHORTCODE_HANDLERS
-        # note this class has not been registered
-        class FooHandler(BlockShortcodeHandler):
-            shortcode_name = "foo"
-
-        registered_handlers = SHORTCODE_HANDLERS.keys()
-        self.assertIn("caption", registered_handlers)
-
     def test_developer_provided_shortcode_handlers_are_registered(self):
         @register("foo")
         class FooHandler(BlockShortcodeHandler):
@@ -247,6 +238,7 @@ class TestShortcodeHandlerRegistration(TestCase):
 
         registered_handlers = SHORTCODE_HANDLERS.keys()
         self.assertIn("foo", registered_handlers)
+        self.assertIn("caption", registered_handlers)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -231,6 +231,15 @@ class TestShortcodesSubstitution(TestCase):
 
 
 class TestShortcodeHandlerRegistration(TestCase):
+    def test_included_shortcode_handlers_are_registered(self):
+        # prime the SHORTCODE_HANDLERS
+        # note this class has not been registered
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        registered_handlers = SHORTCODE_HANDLERS.keys()
+        self.assertIn("caption", registered_handlers)
+
     def test_developer_provided_shortcode_handlers_are_registered(self):
         @register("foo")
         class FooHandler(BlockShortcodeHandler):
@@ -238,7 +247,6 @@ class TestShortcodeHandlerRegistration(TestCase):
 
         registered_handlers = SHORTCODE_HANDLERS.keys()
         self.assertIn("foo", registered_handlers)
-        self.assertIn("caption", registered_handlers)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):


### PR DESCRIPTION
Codebase: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/69

The AC's are all satisfied to this point, although I didn't write any further docs here and the output from pre_filter() is good.

I added a test to make sure the developer added handlers are registered in SHORTCODE_HANDLERS. This does seem to be the only place the keys (registered caption names) are used. I have added an AC to ticket #70 to capture that.