### PR TITLE
#66 write block prefilter class

### DIFF
--- a/docs/shortcodes.md
+++ b/docs/shortcodes.md
@@ -1,0 +1,73 @@
+# Wordpress shortcodes block converter
+
+- [Wordpress shortcodes block converter](#wordpress-shortcodes-block-converter)
+- [Shortcode classes](#shortcode-classes)
+- [Included shortcode handlers](#included-shortcode-handlers)
+  - [Caption shortcode](#caption-shortcode)
+    - [Pre-filter example:](#pre-filter-example)
+    - [Block Creator example](#block-creator-example)
+- [Creating you own shortcode handlers.](#creating-you-own-shortcode-handlers)
+
+# Shortcode classes
+
+The package is able to parse Wordpress shortcodes. 
+
+We provide a base class `BlockShortcodeHandler` that performs the transformation of the raw shortcode into a custom HTML tag using regular expressions.
+
+The custom HTML tag will retain all the parts of the original shortcode which you can make use of when creating the StreamBlock json.
+
+---
+
+# Included shortcode handlers
+
+## Caption shortcode
+
+The package includes a shortcode handler for Wordpress `caption` shortcodes. The handler pre-filter will transform the shortcode into a custom HTML tag. 
+
+The transformation happens in the pre-filter method of the CaptionHandler class.
+
+### Pre-filter example:
+
+*Wordpress shortcode*
+
+```html
+[caption id="attachment_46162" align="aligncenter" width="600"]
+<img class="wp-image-46162 size-full" src="https://www.example.com/images/foo.jpg" alt="This describes the image" width="600" height="338" />
+This is a caption about the image[/caption]
+```
+
+*will be transformed to*
+
+```html
+<wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
+<img class="wp-image-46162 size-full" src="https://www.example.com/images/foo.jpg" alt="This describes the image" width="600" height="338" />
+This is a caption about the image</wagtail_block_caption>
+```
+
+The original wordpress shortcode will be replaced with the custom html above.
+
+### Block Creator example
+
+The StreamField block json is created at the block builder stage. 
+
+The get_block_json() method on the CaptionHandler() class will return the json for the StreamField block. The json is used at the BlockBuilder stage to create the StreamField block.
+
+The StreamField block referenced in the json output will need a matching Wagtail block type in your app.
+
+For example:
+
+```python
+# The Wagtail block included for the caption shortcode handler
+
+class ImageBlock(blocks.StructBlock):
+    image_file = ImageChooserBlock()
+    caption = blocks.CharBlock(required=False)
+
+    class Meta:
+        icon = "image"
+        template = "wagtail_wordpress_import/image_block.html"
+```
+
+# Creating you own shortcode handlers.
+
+This part of the docs it to be completed later...

--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -1,0 +1,128 @@
+import re
+
+from bs4 import BeautifulSoup
+
+SHORTCODE_HANDLERS = {}
+
+
+def register(shortcode_name):
+    def _wrapper(cls):
+        SHORTCODE_HANDLERS[shortcode_name] = cls
+        return cls
+
+    return _wrapper
+
+
+class BlockShortcodeHandler:
+
+    shortcode_name: str
+
+    @property
+    def _pattern(self):
+        """Return a regex to match a block shortcode and capture the attrs and text.
+
+        Given an input:
+
+            "Preface [foo bar=1]some text[/foo] epilogue."
+
+        the regex will match the string between the two "foo" tags, inclusively. The
+        capture group "attrs" will match " bar=1", and capture group "content" will
+        match "some text".
+        """
+        if not hasattr(self, "shortcode_name"):
+            raise NotImplementedError(
+                "Create a subclass of BlockShortcodeHandler with a shortcode_name attribute"
+            )
+
+        return re.compile(
+            r"\["  # matches the opening [
+            + self.shortcode_name
+            + r"\b"  # matches a word boundary
+            + r"(?P<attrs>[^\]]*)"  # capture 'attrs', matching anything but ]
+            + r"\]"  # matches the closing ] of the opening tag
+            + r"(?P<content>.*?)"  # non-greedily captures 'content' between the tags
+            + r"\[\/"  # matches the  [/ of the closing tag
+            + self.shortcode_name
+            + r"\]"  # matches the closing ]
+        )
+
+    def pre_filter(self, string):
+        """Replace all occurrences of the tag with a HTML tag for later parsing.
+
+        Given an input:
+
+            "Preface [foo bar=1]some text[/foo] epilogue."
+
+        this function will return
+
+            "Preface <wagtail_block_foo bar=1>some text</wagtail_block_foo> epilogue."
+        """
+        string, matches = self._pattern.subn(
+            r"<"
+            + self.element_name
+            + r"\g<attrs>>\g<content></"
+            + self.element_name
+            + r">",
+            string,
+        )
+
+        return string
+
+    @property
+    def element_name(self):
+        return f"wagtail_block_{self.shortcode_name}"
+
+
+# Subclasses should declare a shortcode_name, and provide a construct_block method for
+# converting their prefiltered HTML to Wagtail StreamField block JSON.
+@register("caption")
+class CaptionHandler(BlockShortcodeHandler):
+
+    """
+    Sample wordpress caption tag:
+    [caption id="attachment_46162" align="aligncenter" width="600"]
+    <img class="wp-image-46162 size-full" src="https://www.example.com/images/foo.jpg" alt="This describes the image" width="600" height="338" />
+    This is a caption about the image[/caption]
+
+    is replaced by:
+
+    <wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
+    <img class="wp-image-46162 size-full" src="https://www.example.com/images/foo.jpg" alt="This describes the image" width="600" height="338" />
+    This is a caption about the image</wagtail_block_caption>
+
+    in the parent pre-filter method on the parent BlockShortcodeHandler class.
+
+    """
+
+    shortcode_name = "caption"
+
+    def fake_image_getter(self, src):
+        # we have an image fetcher for the rich text field we can implement.
+        # it can be done in ticket #70
+        return {"id": 1, "title": "Image title"}
+
+    def construct_block(self, wagtail_custom_html):
+        soup = BeautifulSoup(wagtail_custom_html, "html.parser")
+
+        custom_html = soup.find("wagtail_block_caption")
+        tag_attrs = custom_html.attrs
+
+        img = custom_html.find("img")
+        img_attrs = img.attrs
+
+        anchor_attrs = None
+        anchor = custom_html.find("a")
+        if anchor:
+            anchor_attrs = anchor.attrs
+
+        image = self.fake_image_getter(img_attrs["src"])
+
+        return {
+            "type": "image_block",
+            "value": {
+                "image_file": image["id"],
+                "tag_attrs": tag_attrs,
+                "image_attrs": img_attrs,
+                "anchor_attrs": anchor_attrs,
+            },
+        }

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -71,6 +71,52 @@ class TestBlockShortcodeRegex(TestCase):
         self.assertFalse(match)
 
 
+class TestShortcodeAttrubuteValidation(TestCase):
+    def test_shortcode_name_not_set(self):
+        class FooHandler(BlockShortcodeHandler):
+            pass
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            handler = FooHandler()
+        self.assertEqual(
+            "Create a subclass of BlockShortcodeHandler with a shortcode_name attribute",
+            str(ctx.exception),
+        )
+
+    def test_shortcode_cannot_start_with_space(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = " foo"
+
+        with self.assertRaises(ValueError) as ctx:
+            handler = FooHandler()
+        self.assertEqual(
+            "The shortcode_name attribute must use upper or lower case letters or digits and cannot contain spaces",
+            str(ctx.exception),
+        )
+
+    def test_shortcode_cannot_end_with_space(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo "
+
+        with self.assertRaises(ValueError) as ctx:
+            handler = FooHandler()
+        self.assertEqual(
+            "The shortcode_name attribute must use upper or lower case letters or digits and cannot contain spaces",
+            str(ctx.exception),
+        )
+
+    def test_shortcode_cannot_contain_spaces(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "fo o"
+
+        with self.assertRaises(ValueError) as ctx:
+            handler = FooHandler()
+        self.assertEqual(
+            "The shortcode_name attribute must use upper or lower case letters or digits and cannot contain spaces",
+            str(ctx.exception),
+        )
+
+
 class TestShortcodesSubstitution(TestCase):
     fodder = (
         "This is a block of text preceding the caption.\n\n"

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -1,0 +1,244 @@
+from bs4 import BeautifulSoup
+from django.test import TestCase
+
+from wagtail_wordpress_import.prefilters.handle_shortcodes import (
+    SHORTCODE_HANDLERS,
+    BlockShortcodeHandler,
+    CaptionHandler,
+    register,
+)
+
+
+class TestBlockShortcodeRegex(TestCase):
+    def test_shortcode_is_found(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        html = "foo[foo]baz[/foo]quux"
+
+        match = handler._pattern.search(html)
+        self.assertEqual(match.start(), 3)
+        self.assertEqual(match.end(), 17)
+        self.assertEqual(match.group("content"), "baz")
+        self.assertEqual(match.group("attrs"), "")
+
+    def test_multiple_shortcodes_are_found(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        html = 'foo[foo]baz[/foo]quux[foo width="12"]spam[/foo]eggs'
+
+        matches = list(handler._pattern.finditer(html))
+
+        self.assertEqual(matches[0].start(), 3)
+        self.assertEqual(matches[0].end(), 17)
+        self.assertEqual(matches[0].group("content"), "baz")
+        self.assertEqual(matches[0].group("attrs"), "")
+        self.assertEqual(matches[1].start(), 21)
+        self.assertEqual(matches[1].end(), 47)
+        self.assertEqual(matches[1].group("content"), "spam")
+        self.assertEqual(matches[1].group("attrs"), ' width="12"')
+
+    def test_content_can_contain_square_brackets(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        html = "embalmed ones[foo][stray dogs][/foo]"
+
+        match = handler._pattern.search(html)
+
+        self.assertEqual(match.start(), 13)
+        self.assertEqual(match.end(), 36)
+        self.assertEqual(
+            match.group("content"),
+            "[stray dogs]",
+        )
+        self.assertEqual(match.group("attrs"), "")
+
+    def test_block_shortcode_handler_requires_the_closing_shortcode_tag(self):
+        """This tests that an aside in square brackets is not accidentally matched."""
+
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        html = "Metasyntactic variables [foo and the like] are common placeholders"
+
+        match = handler._pattern.search(html)
+        self.assertFalse(match)
+
+
+class TestShortcodesSubstitution(TestCase):
+    fodder = (
+        "This is a block of text preceding the caption.\n\n"
+        '[caption id="attachment_46162" align="aligncenter" width="600"]'
+        '<img class="wp-image-46162 size-full" '
+        'src="https://www.example.com/images/foo.jpg" '
+        'alt="This describes the image" width="600" height="338" /> '
+        "<em>[This is a caption about the image (the one above) in "
+        '<a href="https//www.example.com/bar/" target="_blank" '
+        'rel="noopener noreferrer">Glorious Rich Text</a>!]</em>[/caption]'
+        "<strong>The following text is surrounded by strong tags.</strong>"
+    )
+
+    def test_basic(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        html = "ham[foo]eggs[/foo]spam"
+        handler = FooHandler()
+        html = handler.pre_filter(html)
+        self.assertEqual(html, "ham<wagtail_block_foo>eggs</wagtail_block_foo>spam")
+
+    def test_shortcode_at_the_start_of_a_string(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        html = "[foo]radiators[/foo]jam"
+        handler = FooHandler()
+        html = handler.pre_filter(html)
+        self.assertEqual(html, "<wagtail_block_foo>radiators</wagtail_block_foo>jam")
+
+    def test_beautifulsoup_can_parse(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        html = "ham[foo]eggs[/foo]spam"
+        handler = FooHandler()
+        html = handler.pre_filter(html)
+        soup = BeautifulSoup(html, "html.parser")
+        tags = soup.find_all(True)
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(str(tags[0]), "<wagtail_block_foo>eggs</wagtail_block_foo>")
+
+    def test_beautifulsoup_can_parse_attrs(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+
+        html = 'ham[foo quantity=3 state="over easy" garnish="more spam"]eggs[/foo]spam'
+        handler = FooHandler()
+        html = handler.pre_filter(html)
+        soup = BeautifulSoup(html, "html.parser")
+        tags = soup.find_all(True)
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0]["quantity"], "3")
+        self.assertEqual(tags[0]["state"], "over easy")
+        self.assertEqual(tags[0]["garnish"], "more spam")
+
+    def test_caption(self):
+        class CaptionHandler(BlockShortcodeHandler):
+            shortcode_name = "caption"
+
+        html = 'Some pretext[caption width="100"]The content of the tag[/caption]'
+        handler = CaptionHandler()
+        html = handler.pre_filter(html)
+        self.assertEqual(
+            html,
+            'Some pretext<wagtail_block_caption width="100">The content of the tag</wagtail_block_caption>',
+        )
+
+    def test_unclosed_shortcode_rejected_by_block_shortcode_handler(self):
+        """This tests that an aside in square brackets is not accidentally matched."""
+
+        class CaptionHandler(BlockShortcodeHandler):
+            shortcode_name = "caption"
+
+        original = "Some pretext [caption this however you want] "
+        handler = CaptionHandler()
+        html = handler.pre_filter(original)
+        self.assertEqual(html, original)
+
+    def test_known_content(self):
+        class CaptionHandler(BlockShortcodeHandler):
+            shortcode_name = "caption"
+
+        html = (
+            "This is a block of text preceding the caption.\n\n"
+            '[caption id="attachment_46162" align="aligncenter" width="600"]'
+            '<img class="wp-image-46162 size-full" '
+            'src="https://www.example.com/images/foo.jpg" '
+            'alt="This describes the image" width="600" height="338" /> '
+            "<em>[This is a caption about the image (the one above) in "
+            '<a href="https//www.example.com/bar/" target="_blank" '
+            'rel="noopener noreferrer">Glorious Rich Text</a>!]</em>'
+            "[/caption]"
+            "<strong>The following text is surrounded by strong tags.</strong>"
+        )
+        handler = CaptionHandler()
+        html = handler.pre_filter(html)
+        self.assertEqual(
+            html,
+            "This is a block of text preceding the caption.\n\n"
+            '<wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">'
+            '<img class="wp-image-46162 size-full" '
+            'src="https://www.example.com/images/foo.jpg" '
+            'alt="This describes the image" width="600" height="338" /> '
+            "<em>[This is a caption about the image (the one above) in "
+            '<a href="https//www.example.com/bar/" target="_blank" '
+            'rel="noopener noreferrer">Glorious Rich Text</a>!]</em>'
+            "</wagtail_block_caption>"
+            "<strong>The following text is surrounded by strong tags.</strong>",
+        )
+
+
+class TestShortcodeHandlerRegistration(TestCase):
+    def test_caption_handlers_are_registered(self):
+        @register("caption")
+        class CaptionHandler(BlockShortcodeHandler):
+            shortcode_name = "caption"
+
+        @register("form")
+        class FormHandler(BlockShortcodeHandler):
+            shortcode_name = "form"
+
+        self.assertEqual(len(SHORTCODE_HANDLERS), 2)
+
+        registered_handlers = SHORTCODE_HANDLERS.keys()
+
+        self.assertIn("caption", registered_handlers)
+        self.assertIn("form", registered_handlers)
+
+
+class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):
+    def test_construct_block_method_output(self):
+        handler = CaptionHandler()
+        wagtail_custom_html = (
+            '<wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">'
+            '<img class="wp-image-46162 size-full" '
+            'src="https://www.example.com/images/foo.jpg" '
+            'alt="This describes the image" width="600" height="338" /> '
+            "<em>[This is a caption about the image (the one above) in "
+            '<a href="https//www.example.com/bar/" target="_blank" '
+            'rel="noopener noreferrer">Glorious Rich Text</a>!]</em>'
+            "</wagtail_block_caption>"
+        )
+        json = handler.construct_block(wagtail_custom_html)
+        self.assertDictEqual(
+            json,
+            {
+                "type": "image_block",
+                "value": {
+                    "image_file": 1,
+                    "tag_attrs": {
+                        "id": "attachment_46162",
+                        "align": "aligncenter",
+                        "width": "600",
+                    },
+                    "image_attrs": {
+                        "class": ["wp-image-46162", "size-full"],
+                        "src": "https://www.example.com/images/foo.jpg",
+                        "alt": "This describes the image",
+                        "width": "600",
+                        "height": "338",
+                    },
+                    "anchor_attrs": {
+                        "href": "https//www.example.com/bar/",
+                        "target": "_blank",
+                        "rel": ["noopener", "noreferrer"],
+                    },
+                },
+            },
+        )


### PR DESCRIPTION
Satisfies https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/66

At this point the included shortcode handler is registered. There's no output here yet that is added to the wordpress body content.

The tests here will ensure the handler is added to SHORTCODE_HANDLERS 

Also tests the `pre_filter` method will find the shortcode from a passed in `shortcaode_name` and output the custom HTML tag.

Also tests the `construct_block` method outputs StreamField json. The json may be changed in upcoming work to suit the final use case.

The initial docs have further work done in upcoming PR's