### PR TITLE
fix/#80 headings in richtext

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -67,36 +67,6 @@ def conf_html_tags_to_blocks():
                 },
             ),
             (
-                "h2",
-                {
-                    "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_heading_block",
-                },
-            ),
-            (
-                "h3",
-                {
-                    "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_heading_block",
-                },
-            ),
-            (
-                "h4",
-                {
-                    "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_heading_block",
-                },
-            ),
-            (
-                "h5",
-                {
-                    "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_heading_block",
-                },
-            ),
-            (
-                "h6",
-                {
-                    "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_heading_block",
-                },
-            ),
-            (
                 "table",
                 {
                     "FUNCTION": "wagtail_wordpress_import.block_builder_defaults.build_table_block",

--- a/wagtail_wordpress_import/test/fixtures/raw_html.txt
+++ b/wagtail_wordpress_import/test/fixtures/raw_html.txt
@@ -4,7 +4,7 @@
 
 <a href="#ideas"><strong>Lorem ipsum dolor sit (xcounterx) amet!</strong></a>
 <a href="https://www.budgetsaresexy.com/files/personal-finance-culminating-assignment.pdf">Read this</a>
-<h2><strong>Lorem ipsum dolor sit amet?</strong></h2>
+<h1><strong>Lorem ipsum dolor sit amet?</strong></h1>
 
 <p>Absolute image url.
     <a href="#">

--- a/wagtail_wordpress_import/test/fixtures/raw_html.txt
+++ b/wagtail_wordpress_import/test/fixtures/raw_html.txt
@@ -1,3 +1,4 @@
+<!-- BE CAREFUL WHEN ALTERING THIS FIXTURE AS THE ORDER OF TAG MATTERS -->
 <img src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" alt="">
 
 <span style="font-weight: bold;font-style:italic;">Lorem ipsum (xcounterx) dolor sit amet</span>

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -1,6 +1,7 @@
 import os
 
 from bs4 import BeautifulSoup
+import bs4
 from django.conf import settings
 from django.test import TestCase, override_settings, modify_settings
 from wagtail_wordpress_import.block_builder import BlockBuilder
@@ -161,6 +162,19 @@ class TestBlockBuilderBuild(TestCase):
     def test_heading_blocks_count(self):
         blocks = [block["type"] for block in self.blocks if block["type"] == "heading"]
         self.assertEqual(len(blocks), 1)
+
+    def test_richtext_block_3_content(self):
+        """The expected content here should be lines 9 - 24 of raw_html.txt"""
+        rich_text_content = BeautifulSoup(self.blocks[3]["value"], "html.parser")
+
+        paragraph = rich_text_content.find("p")
+        self.assertIsInstance(paragraph, bs4.element.Tag)
+
+        list = rich_text_content.find("ul")
+        self.assertIsInstance(list, bs4.element.Tag)
+
+        heading_2 = rich_text_content.find("h2")
+        self.assertIsInstance(heading_2, bs4.element.Tag)
 
 
 class TestBlockBuilderDefaultsBaseUrl(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -160,7 +160,7 @@ class TestBlockBuilderBuild(TestCase):
 
     def test_heading_blocks_count(self):
         blocks = [block["type"] for block in self.blocks if block["type"] == "heading"]
-        self.assertEqual(len(blocks), 2)
+        self.assertEqual(len(blocks), 1)
 
 
 class TestBlockBuilderDefaultsBaseUrl(TestCase):


### PR DESCRIPTION
Removed the default config for the headings `h2` - `h6`. These headings are now parsed into a rich_text block

I have left `h1` in the config so that they are built as a separate block.