### PR TITLE
fix/#79-reduce-command-flexibility

### DIFF
--- a/wagtail_wordpress_import/management/commands/reduce_xml.py
+++ b/wagtail_wordpress_import/management/commands/reduce_xml.py
@@ -17,8 +17,7 @@ class Command(BaseCommand):
     help = """Utils to reduce xml file size by removing unwanted tags."""
 
     """
-    Tags to be removed item > wp:comment 
-    TODO: this would be better made felxible
+    Tags to be removed item > wp:comment
     """
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Codebase ticket: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/79

This work removes the comment TODO