### PR TITLE
Import hooks multiple handlers

### DIFF
--- a/wagtail_wordpress_import/test/tests/test_import_hooks.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks.py
@@ -436,10 +436,13 @@ class TestImportHooksItemsCacheMethods(TestCase):
         )
 
         self.process_import(built_file)
-        function, actions = self.importer.items_cache._get_hook_handler_data()
-        page, data, items_cache = import_string(function)(
-            self.imported_pages[0], actions, self.importer.items_cache.__dict__
-        )
+        for (
+            hook,
+            (function, actions),
+        ) in self.importer.items_cache._get_hook_handler_data().items():
+            page, data, items_cache = function(
+                self.imported_pages[0], actions, self.importer.items_cache.__dict__
+            )
 
         self.assertIsInstance(page, Page)
         self.assertEqual(page.title, "A title")

--- a/wagtail_wordpress_import/test/tests/test_import_hooks.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks.py
@@ -344,12 +344,8 @@ class WordpressImporterTestsCheckXmlItemsCached(TestCase):
         self.assertEqual(len(self.importer.items_cache.__dict__.keys()), 2)
 
 
-def foo_handler(page, data, items_cache):
-    return page, data, items_cache
-
-
-def bar_handler(page, data, items_cache):
-    return page, data, items_cache
+foo_handler = mock.Mock()
+bar_handler = mock.Mock()
 
 
 @override_settings(
@@ -436,21 +432,21 @@ class TestImportHooksItemsCacheMethods(TestCase):
         )
 
         self.process_import(built_file)
-        for (
-            hook,
-            (function, actions),
-        ) in self.importer.items_cache._get_hook_handler_data().items():
-            page, data, items_cache = function(
-                self.imported_pages[0], actions, self.importer.items_cache.__dict__
-            )
+        foo_handler.assert_called_once_with(
+            self.imported_pages[0].specific,
+            "foodatatagname",
+            self.importer.items_cache.__dict__,
+        )
+        bar_handler.assert_called_once_with(
+            self.imported_pages[0].specific,
+            "bardatatagname",
+            self.importer.items_cache.__dict__,
+        )
 
-        self.assertIsInstance(page, Page)
-        self.assertEqual(page.title, "A title")
-        self.assertIsInstance(data, str)
-        self.assertEqual(data, "foodatatagname")
-        self.assertIsInstance(items_cache, dict)
-        self.assertEqual(items_cache["foo"][0]["title"], "foo-item")
-        self.assertEqual(items_cache["bar"][0]["title"], "bar-item")
+        cache = self.importer.items_cache.__dict__
+        self.assertIsInstance(cache, dict)
+        self.assertEqual(cache["foo"][0]["title"], "foo-item")
+        self.assertEqual(cache["bar"][0]["title"], "bar-item")
 
     def test_handler_functions_are_registered(self):
         items_cache = ItemsCache()

--- a/wagtail_wordpress_import/test/tests/test_import_hooks.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks.py
@@ -9,9 +9,7 @@ from unittest import mock
 from wagtail.core.models import Page
 from wagtail_wordpress_import.block_builder import conf_promote_child_tags
 from wagtail_wordpress_import.functions import node_to_dict
-from wagtail_wordpress_import.importers.import_hooks import (
-    ItemsCache,
-)
+from wagtail_wordpress_import.importers.import_hooks import ItemsCache
 from wagtail_wordpress_import.importers.wordpress import WordpressImporter
 from wagtail_wordpress_import.logger import Logger
 
@@ -268,9 +266,7 @@ class WordpressImporterTestsCheckXmlItemsCached(TestCase):
         return imported_pages
 
     @mock.patch.object(
-        ItemsCache,
-        "process",
-        process,
+        ItemsCache, "process", process,
     )
     def process_import(self, xml_stream):
         self.importer = WordpressImporter(xml_stream)

--- a/wagtail_wordpress_import/test/tests/test_import_hooks.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks.py
@@ -452,30 +452,6 @@ class TestImportHooksItemsCacheMethods(TestCase):
         self.assertEqual(items_cache["foo"][0]["title"], "foo-item")
         self.assertEqual(items_cache["bar"][0]["title"], "bar-item")
 
-    def test_fails_foo_handler_function_is_registered(self):
-        # FIXME This is here to illustrate an issue with the current data structure.
-        # Delete this test method once test_handler_functions_are_registered passes.
-        items_cache = ItemsCache()
-        func, data = items_cache._get_hook_handler_data()
-        self.assertEqual(
-            func, settings.WORDPRESS_IMPORT_HOOKS_ITEMS_TO_CACHE["foo"]["FUNCTION"]
-        )
-        self.assertEqual(
-            data, settings.WORDPRESS_IMPORT_HOOKS_ITEMS_TO_CACHE["foo"]["DATA_TAG"]
-        )
-
-    def test_fails_bar_handler_function_is_registered(self):
-        # FIXME This is here to illustrate an issue with the current data structure.
-        # Delete this test method once test_handler_functions_are_registered passes.
-        items_cache = ItemsCache()
-        func, data = items_cache._get_hook_handler_data()
-        self.assertEqual(
-            func, settings.WORDPRESS_IMPORT_HOOKS_ITEMS_TO_CACHE["bar"]["FUNCTION"]
-        )
-        self.assertEqual(
-            data, settings.WORDPRESS_IMPORT_HOOKS_ITEMS_TO_CACHE["bar"]["DATA_TAG"]
-        )
-
     def test_handler_functions_are_registered(self):
         items_cache = ItemsCache()
         registry = items_cache._get_hook_handler_data()


### PR DESCRIPTION
This attempts to fix the issue whereby it was not possible to register multiple distinct import function handlers. All registered XML tags to cache and post-process would have been passed to the same function, even if multiple functions were defined in the settings.

See ticket https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/73