### PR TITLE
Documentation for setting the BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A package for Wagtail CMS to import WordPress blog content from an XML file into
   - [Requirements](#requirements)
   - [Compatibility](#compatibility)
   - [Initial app and package setup](#initial-app-and-package-setup)
+    - [BASE_URL for importing images and documents](#base_url-for-importing-images-and-documents)
     - [First steps to configure your Wagtail app](#first-steps-to-configure-your-wagtail-app)
   - [Running the import command](#running-the-import-command)
     - [Optional command arguments](#optional-command-arguments)
@@ -34,6 +35,14 @@ The package has been developed and tested with:
 3. Place your XML files somewhere on your disk. The file can have any name you choose.
 4. Create a `log` folder in the root of your site. The import script will need to write report files to this folder, you may need to set the permissions on the folder.
 5. Add `"wagtail_wordpress_import"` to your INSTALLED_APPS config in your settings.py file.
+
+### BASE_URL for importing images and documents
+
+The importer will need to know what the URL is for the website to download images and documents from.
+
+Set the `BASE_URL` setting in your sites settings to the URL of the website that the images and documents will be imported from.
+
+*If you need to use a different URL in `BASE_URL` you can use `WAGTAIL_WORDPRESS_IMPORTER_BASE_URL`.*
 
 ### First steps to configure your Wagtail app
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A package for Wagtail CMS to import WordPress blog content from an XML file into
   - [Requirements](#requirements)
   - [Compatibility](#compatibility)
   - [Initial app and package setup](#initial-app-and-package-setup)
-    - [BASE_URL for importing images and documents](#base_url-for-importing-images-and-documents)
+    - [Site URL for importing images and documents](#site-url-for-importing-images-and-documents)
     - [First steps to configure your Wagtail app](#first-steps-to-configure-your-wagtail-app)
   - [Running the import command](#running-the-import-command)
     - [Optional command arguments](#optional-command-arguments)
@@ -36,13 +36,9 @@ The package has been developed and tested with:
 4. Create a `log` folder in the root of your site. The import script will need to write report files to this folder, you may need to set the permissions on the folder.
 5. Add `"wagtail_wordpress_import"` to your INSTALLED_APPS config in your settings.py file.
 
-### BASE_URL for importing images and documents
+### Site URL for importing images and documents
 
-The importer will need to know what the URL is for the website to download images and documents from.
-
-Set the `BASE_URL` setting in your sites settings to the URL of the website that the images and documents will be imported from.
-
-*If you need to use a different URL in `BASE_URL` you can use `WAGTAIL_WORDPRESS_IMPORTER_BASE_URL`.*
+Add a setting of `WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN` in your sites settings and set it to the the URL of the website that the images and documents will be imported from.
 
 ### First steps to configure your Wagtail app
 

--- a/wagtail_wordpress_import/management/commands/import_xml.py
+++ b/wagtail_wordpress_import/management/commands/import_xml.py
@@ -1,9 +1,9 @@
 import os
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from wagtail_wordpress_import.importers.wordpress import WordpressImporter
 from wagtail_wordpress_import.logger import Logger
-from wagtail_wordpress_import.block_builder_defaults import conf_domain_prefix
 
 LOG_DIR = "log"
 
@@ -57,10 +57,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-        if not conf_domain_prefix():
+        if not getattr(settings, "WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN", ""):
             self.stdout.write(
                 self.style.ERROR(
-                    "BASE_URL or WAGTAIL_WORDPRESS_IMPORTER_BASE_URL: needs to be added to your settings"
+                    "WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN: is missing in your site settings"
                 )
             )
             exit()

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -1,9 +1,8 @@
 import os
 
-from bs4 import BeautifulSoup
 import bs4
-from django.conf import settings
-from django.test import TestCase, override_settings, modify_settings
+from bs4 import BeautifulSoup
+from django.test import TestCase, override_settings
 from wagtail_wordpress_import.block_builder import BlockBuilder, conf_promote_child_tags
 from wagtail_wordpress_import.block_builder_defaults import (
     build_block_quote_block,
@@ -12,7 +11,6 @@ from wagtail_wordpress_import.block_builder_defaults import (
     build_iframe_block,
     build_image_block,
     build_table_block,
-    conf_domain_prefix,
     get_absolute_src,
     get_alignment_class,
     get_image_alt,
@@ -158,7 +156,7 @@ class TestBlockBuilderBlockDefaults(TestCase):
         self.assertTrue(output["value"].startswith("<table"))
 
 
-@override_settings(BASE_URL="http://www.example.com")
+@override_settings(WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://www.example.com")
 class TestBlockBuilderBuild(TestCase):
     def setUp(self):
         raw_html_file = open(f"{FIXTURES_PATH}/raw_html.txt", "r")
@@ -200,31 +198,7 @@ class TestBlockBuilderBuild(TestCase):
         self.assertIsInstance(heading_2, bs4.element.Tag)
 
 
-class TestBlockBuilderDefaultsBaseUrl(TestCase):
-    @override_settings(BASE_URL="http://www.example.com")
-    def test_conf_domain_prefix(self):
-        prefix = conf_domain_prefix()
-        self.assertEqual(prefix, "http://www.example.com")
-
-    @override_settings(WAGTAIL_WORDPRESS_IMPORTER_BASE_URL="http://www.example.com")
-    def test_conf_domain_prefix(self):
-        prefix = conf_domain_prefix()
-        self.assertEqual(prefix, "http://www.example.com")
-
-    @override_settings(
-        BASE_URL="http://www.example.com",
-        WAGTAIL_WORDPRESS_IMPORTER_BASE_URL="http://www.domain.com",
-    )  # WAGTAIL_WORDPRESS_IMPORTER_BASE_URL takes preference
-    def test_conf_domain_prefix(self):
-        prefix = conf_domain_prefix()
-        self.assertEqual(prefix, "http://www.domain.com")
-
-    @override_settings()  # no BASE_URL or WAGTAIL_WORDPRESS_IMPORTER_BASE_URL
-    def test_conf_domain_prefix_no_base_url_config(self):
-        prefix = conf_domain_prefix()
-        self.assertIsNone(prefix)
-
-
+@override_settings(WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://www.example.com")
 class TestRichTextImageLinking(TestCase):
     def test_images_linked_rich_text(self):
         """

--- a/wagtail_wordpress_import/test/tests/test_wordpress_importer.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_importer.py
@@ -17,6 +17,7 @@ IMPORTER_RUN_PARAMS_TEST = {
 }
 
 
+@override_settings(WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://www.example.com")
 class WordpressImporterTests(TestCase):
     fixtures = [
         f"{FIXTURES_PATH}/dump.json",
@@ -146,7 +147,10 @@ IMPORTER_RUN_PARAMS_TEST_OVERRIDE_1 = {
 }
 
 
-@override_settings(WAGTAIL_WORDPRESS_IMPORT_YOAST_PLUGIN_ENABLED=True)
+@override_settings(
+    WAGTAIL_WORDPRESS_IMPORT_YOAST_PLUGIN_ENABLED=True,
+    WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://www.example.com",
+)
 class WordpressImporterTestsYoastEnabled(TestCase):
     """
     We check here that if the Yoast plugin is enabled import the search description

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -13,9 +13,6 @@ from wagtail_wordpress_import.importers.wordpress import (
     WordpressItem,
 )
 from wagtail_wordpress_import.logger import Logger
-from wagtail.core.fields import StreamField
-from wagtail.core.blocks import RichTextBlock
-from wagtail_wordpress_import.importers.wordpress import WordpressImporter
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
 FIXTURES_PATH = BASE_PATH + "/fixtures"
@@ -106,7 +103,7 @@ class WordpressItemTests(TestCase):
 
 
 @override_settings(
-    BASE_URL="http://localhost:8000",
+    WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://localhost:8000",
     WAGTAIL_WORDPRESS_IMPORT_CATEGORY_PLUGIN_ENABLED=True,
     WAGTAIL_WORDPRESS_IMPORT_CATEGORY_PLUGIN_MODEL="example.models.Category",
 )  # testing requires a live domain for requests to use, this is something I need to change before package release
@@ -166,7 +163,7 @@ class WordpressItemImportTests(TestCase):
 
 
 @override_settings(
-    BASE_URL="http://localhost:8000",
+    WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://localhost:8000",
     WAGTAIL_WORDPRESS_IMPORT_CATEGORY_PLUGIN_ENABLED=True,
     WAGTAIL_WORDPRESS_IMPORT_CATEGORY_PLUGIN_MODEL="example.models.Category",
 )  # testing requires a live domain for requests to use, this is something I need to change before package release


### PR DESCRIPTION
# Documentation for setting the BASE_URL

This adds the information to the main readme for the usage of the BASE_URL setting

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/93

WAGTAIL_WORDPRESS_IMPORTER_BASE_URL is renamed to WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN

---

- Testing
    - [x] CI passes
- Documentation.
    - [x] This PR adds or updates documentation
