### PR TITLE
Feature/inline shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Running this command will import all WordPress 'post' and 'page' types to the 'P
 - [Categories Import](docs/categories.md)
 - [Import Hooks](docs/import_hooks.md)
 - [Prefilters](docs/prefilters.md)
-- [WordPress Shortcodes](docs/shortcodes.md)
+- [WordPress Block Shortcodes](docs/block_shortcodes.md)
+- [WordPress Inline Shortcodes](docs/inline_shortocdes.md)
 - [Yoast Import](docs/yoast.md)
 
 ## Developer Tooling

--- a/docs/block_shortcodes.md
+++ b/docs/block_shortcodes.md
@@ -9,7 +9,7 @@
 
 ## Block Shortcode handler class
 
-The package is able to parse Wordpress block shortcodes.
+The package is able to parse WordPress block shortcodes.
 
 We provide a base class [BlockShortcodeHandler](/wagtail_wordpress_import/prefilters/handle_shortcodes.py#L27) that performs the transformation of the raw shortcode into a custom HTML tag using a regular expression.
 

--- a/docs/block_shortcodes.md
+++ b/docs/block_shortcodes.md
@@ -1,17 +1,17 @@
-# Converting Wordpress shortcodes to StreamField blocks
+# Converting Wordpress block shortcodes to StreamField blocks
 
-- [Converting Wordpress shortcodes to StreamField blocks](#converting-wordpress-shortcodes-to-streamfield-blocks)
-  - [Shortcode handler classes](#shortcode-handler-classes)
+- [Converting Wordpress block shortcodes to StreamField blocks](#converting-wordpress-block-shortcodes-to-streamfield-blocks)
+  - [Block Shortcode handler class](#block-shortcode-handler-class)
   - [Caption shortcode handler (included)](#caption-shortcode-handler-included)
     - [CaptionHandler Pre-filter](#captionhandler-pre-filter)
     - [Caption StreamField block constructor](#caption-streamfield-block-constructor)
   - [How to create your own shortcode handlers](#how-to-create-your-own-shortcode-handlers)
 
-## Shortcode handler classes
+## Block Shortcode handler class
 
-The package is able to parse Wordpress shortcodes.
+The package is able to parse Wordpress block shortcodes.
 
-We provide a base class [BlockShortcodeHandler](wagtail_wordpress_import/prefilters/handle_shortcodes.py#L27) that performs the transformation of the raw shortcode into a custom HTML tag using a regular expression.
+We provide a base class [BlockShortcodeHandler](/wagtail_wordpress_import/prefilters/handle_shortcodes.py#L27) that performs the transformation of the raw shortcode into a custom HTML tag using a regular expression.
 
 The custom HTML tag will retain all the parts of the original shortcode which you can use to create the StreamField block.
 
@@ -21,7 +21,7 @@ The package includes a handler for the Wordpress `caption` shortcode called `Cap
 
 ## Caption shortcode handler (included)
 
-[View CaptionHandler Source](wagtail_wordpress_import/prefilters/handle_shortcodes.py#L102)
+[View CaptionHandler Source](/wagtail_wordpress_import/prefilters/handle_shortcodes.py#L102)
 
 ### CaptionHandler Pre-filter
 
@@ -47,13 +47,13 @@ would be transformed and replaced with:
 
 ### Caption StreamField block constructor
 
-The StreamField block dict is created from the custom HTML tag at the block builder stage. The [construct_block()](wagtail_wordpress_import/prefilters/handle_shortcodes.py#L133) method of the CaptionHandler() class is passed the custom HTML tag by the block builder for parsing and will return a dict for the StreamField block.
+The StreamField block dict is created from the custom HTML tag at the block builder stage. The [construct_block()](/wagtail_wordpress_import/prefilters/handle_shortcodes.py#L133) method of the CaptionHandler() class is passed the custom HTML tag by the block builder for parsing and will return a dict for the StreamField block.
 
 *The StreamField block name used in the dict will need a matching Wagtail block type in your app. We provide an ImageBlock for the Caption shortcode handler.*
 
 ## How to create your own shortcode handlers
 
-You will need to create a class that inherits from the provided `BlockShortcodeHandler` [source](wagtail_wordpress_import/prefilters/handle_shortcodes.py)
+You will need to create a class that inherits from the provided `BlockShortcodeHandler` [source](/wagtail_wordpress_import/prefilters/handle_shortcodes.py)
 
 A complete shortcode example:
 

--- a/docs/inline_shortcodes.md
+++ b/docs/inline_shortcodes.md
@@ -1,0 +1,119 @@
+# Converting Wordpress inline shortcodes for Draftail editor
+
+- [Converting Wordpress inline shortcodes for Draftail editor](#converting-wordpress-inline-shortcodes-for-draftail-editor)
+  - [Shortcode handler class](#shortcode-handler-class)
+  - [How to create your own inline shortcode handler](#how-to-create-your-own-inline-shortcode-handler)
+  - [An example of how to add a shortcode handler for the Draftail editor](#an-example-of-how-to-add-a-shortcode-handler-for-the-draftail-editor)
+    - [Stock inline shortcode handler class](#stock-inline-shortcode-handler-class)
+    - [Stock inline shortcode handler configuration](#stock-inline-shortcode-handler-configuration)
+  - [How to test this example works](#how-to-test-this-example-works)
+
+## Shortcode handler class
+
+The package is able to transform Wordpress inline shortcodes.
+
+We provide a base class [InlineShortcodeHandler](/wagtail-wordpress-import/wagtail_wordpress_import/handle_inline_shortcodes.py) that performs regular expression search for a shortcode.
+
+## How to create your own inline shortcode handler
+
+1. You will need to create a subclass of InlineShortcodeHandler.
+2. Then you will need to extend the Draftail editor to recognise the new HTML tag that your shortcode handler will generate.
+
+## An example of how to add a shortcode handler for the Draftail editor
+
+Extending the Draftail editor is fully documented in the [Wagtail Documentation](https://docs.wagtail.io/en/stable/extending/extending_draftail.html).
+
+This example will enable the stock chooser display in the Draftail editor. It's a fully functioning but somewhat fictional example but should help you get started with your own inline shortcode handler.
+
+The complete Wagtail Documentation example can be [Viewed Here](https://docs.wagtail.io/en/stable/extending/extending_draftail.html#creating-new-entities) and this is the first step you should take to get the example working in your own project.
+
+We are making the assumption that in your imported HTML that will be part of a RichText block there is an inline shortcode that will represent a stock to be displayed both in the editor and in the front end.
+
+The word press shortcode will be transformed during the import form  `[stock symbol="TSLA"]` to `<span data-stock="TSLA">$TSLA</span>` before being saved to the RichText block.
+
+You will only need to write one class to handle a shortcode like this. the symbol is dynamic and can be different across multiple shortcode in hte same HTML content.
+
+All shortcodes of the type `[stock symbol="any-valid-symbol"]` will be transformed.
+
+### Stock inline shortcode handler class
+
+```python
+# you can give this module any name or add the class to an existing module
+
+# import the base handler class
+from wagtail_wordpress_import.handle_inline_shortcodes import (
+    InlineShortcodeHandler, 
+)
+
+
+# Subclasses should declare a shortcode_name and provide
+# a construct_html_tag method for converting the shortcode to a HTML tag.
+# @register()
+class StockHandler(InlineShortcodeHandler):
+    """
+    The Wordpress shortcode is replaced by a custom HTML tag. 
+    The shortcode attributes are preserved and can be included in the custom HTML tag.
+
+    Sample wordpress stock shortcode:
+    [stock symbol="TSLA"]
+
+    all matching shortcodes are replaced by:
+
+    <span data-stock="TSLA">$TSLA</span>
+    """
+
+    # The shortcode name that is after the first "[" and the 
+    # matching for the shortcode name will end at the first space
+    shortcode_name = "stock"
+
+    """You must implement this method in your own class"""
+    def construct_html_tag(self, html):
+        # It will receive the `html` string content of the RichText block
+
+        """ This is fully functioning code for the stock example. You may need 
+        to use your own logic here depending on your requirements.
+        
+        The output needs be the `html` string received with the  modifications 
+        your code makes.
+        """
+
+        matches = self._pattern.finditer(html) # find all matches of the shortcode
+
+        for match in matches: # Loop through the matches
+
+            # Get the shortcode attributes using the parent class method
+            # or you can implement your own method for this.
+            attrs = self.get_shortcode_attrs(match.groupdict()["attrs"])
+
+            # Modify the `html` string by replacing the shortcode with a HTML tag.
+            html = html.replace(
+                match.group(),
+                f'<{self.element_name} data-{self.shortcode_name}="{attrs["symbol"]}">${attrs["symbol"]}</span>',
+            )
+
+        return html # always return the modified `html` as a string
+
+# Provide a reference to the class thats equal to the last part of your 
+# configuration dotted path. See configuration example below.
+stock_handler = StockHandler()
+```
+
+### Stock inline shortcode handler configuration
+
+Add the following configuration to your own settings.
+
+```python
+WAGTAIL_WORDPRESS_IMPORTER_INLINE_SHORTCODE_HANDLERS = [
+    "path.to.your.stock_handler",
+]
+```
+
+The package will always call the `construct_html_tag` method of you handler class.
+
+## How to test this example works
+
+Find an `item` in the XML file you are importing and add a stock shortcode of `[stock symbol="TSLA"]` to the `<content:encoded></content:encoded>` tag. Alongside any of the existing content.
+
+Now run the import command. When the command completes check the RichText content for the page you added the stock shortcode to. It should be visible in the editor just as if you had used the toolbar button to add a stock symbol.
+
+If you have implemented the front end part of the Wagtail example (the last JavaScript code snippet) you should also see the stock symbol graph.

--- a/docs/inline_shortcodes.md
+++ b/docs/inline_shortcodes.md
@@ -111,7 +111,7 @@ The package will always call the `construct_html_tag` method of you handler clas
 
 ## How to test this example works
 
-Find an `item` in the XML file you are importing and add a stock shortcode of `[stock symbol="TSLA"]` to the `<content:encoded></content:encoded>` tag. The stock shortcode can be inline within a piece of text or on it's own line.
+Find an `item` in the XML file you are importing and add a stock shortcode of `[stock symbol="TSLA"]` to the `<content:encoded></content:encoded>` tag. The stock shortcode can be inline within a piece of text or on its own line.
 
 Now run the import command. When the command completes check the RichText content for the page you added the stock shortcode to. It should be visible in the editor just as if you had used the toolbar button to add a stock symbol.
 

--- a/docs/inline_shortcodes.md
+++ b/docs/inline_shortcodes.md
@@ -88,7 +88,7 @@ class StockHandler(InlineShortcodeHandler):
             # Modify the `html` string by replacing the shortcode with a HTML tag.
             html = html.replace(
                 match.group(),
-                f'<{self.element_name} data-{self.shortcode_name}="{attrs["symbol"]}">${attrs["symbol"]}</span>',
+                f'<{self.element_name} data-{self.shortcode_name}="{attrs["symbol"]}">${attrs["symbol"]}</{self.element_name}>',
             )
 
         return html # always return the modified `html` as a string

--- a/docs/inline_shortcodes.md
+++ b/docs/inline_shortcodes.md
@@ -16,8 +16,8 @@ We provide a base class [InlineShortcodeHandler](/wagtail-wordpress-import/wagta
 
 ## How to create your own inline shortcode handler
 
-1. You will need to create a subclass of InlineShortcodeHandler.
-2. Then you will need to extend the Draftail editor to recognise the new HTML tag that your shortcode handler will generate.
+1. Create a subclass of InlineShortcodeHandler.
+2. Extend the Draftail editor to recognise the new HTML tag that your shortcode handler will generate.
 
 ## An example of how to add a shortcode handler for the Draftail editor
 
@@ -27,11 +27,11 @@ This example will enable the stock chooser display in the Draftail editor. It's 
 
 The complete Wagtail Documentation example can be [Viewed Here](https://docs.wagtail.io/en/stable/extending/extending_draftail.html#creating-new-entities) and this is the first step you should take to get the example working in your own project.
 
-We are making the assumption that in your imported HTML that will be part of a RichText block there is an inline shortcode that will represent a stock to be displayed both in the editor and in the front end.
+We assume here that you are importing HTML that will be part of a RichText block, and that the HTML contains an inline shortcode `[stock symbol="TSLA"]`, that you want to be editable in the Draftail editor, and to be displayed in the rendered page.
 
-The word press shortcode will be transformed during the import form  `[stock symbol="TSLA"]` to `<span data-stock="TSLA">$TSLA</span>` before being saved to the RichText block.
+The WordPress shortcode will be transformed during the import, from `[stock symbol="TSLA"]` to `<span data-stock="TSLA">$TSLA</span>` before being saved to the RichText block.
 
-You will only need to write one class to handle a shortcode like this. the symbol is dynamic and can be different across multiple shortcode in hte same HTML content.
+You will only need to write one class to handle a shortcode like this. The symbol is dynamic and can be different across multiple shortcodes in the same HTML content.
 
 All shortcodes of the type `[stock symbol="any-valid-symbol"]` will be transformed.
 
@@ -48,7 +48,6 @@ from wagtail_wordpress_import.handle_inline_shortcodes import (
 
 # Subclasses should declare a shortcode_name and provide
 # a construct_html_tag method for converting the shortcode to a HTML tag.
-# @register()
 class StockHandler(InlineShortcodeHandler):
     """
     The Wordpress shortcode is replaced by a custom HTML tag. 
@@ -112,7 +111,7 @@ The package will always call the `construct_html_tag` method of you handler clas
 
 ## How to test this example works
 
-Find an `item` in the XML file you are importing and add a stock shortcode of `[stock symbol="TSLA"]` to the `<content:encoded></content:encoded>` tag. Alongside any of the existing content.
+Find an `item` in the XML file you are importing and add a stock shortcode of `[stock symbol="TSLA"]` to the `<content:encoded></content:encoded>` tag. The stock shortcode can be inline within a piece of text or on it's own line.
 
 Now run the import command. When the command completes check the RichText content for the page you added the stock shortcode to. It should be visible in the editor just as if you had used the toolbar button to add a stock symbol.
 

--- a/wagtail_wordpress_import/blocks.py
+++ b/wagtail_wordpress_import/blocks.py
@@ -49,30 +49,7 @@ class QuoteBlock(blocks.StructBlock):
 
 
 class WPImportStreamBlocks(blocks.StreamBlock):
-    rich_text = blocks.RichTextBlock(
-        features=[
-            "anchor-identifier",
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6",
-            "bold",
-            "italic",
-            "ol",
-            "ul",
-            "hr",
-            "link",
-            "document-link",
-            "image",
-            "embed",
-            "superscript",
-            "subscript",
-            "strikethrough",
-            "blockquote",
-        ]
-    )
+    rich_text = blocks.RichTextBlock()
     heading = HeadingBlock()
     image = ImageBlock()
     block_quote = QuoteBlock()

--- a/wagtail_wordpress_import/handle_inline_shortcodes.py
+++ b/wagtail_wordpress_import/handle_inline_shortcodes.py
@@ -18,7 +18,7 @@ class InlineShortcodeHandler:
             )
         pattern = re.compile(r"^\S[a-zA-Z0-9_\S]+\S$")
         # shortcode_name must use upper or lower case letters or digits and cannot contain spaces
-        if not re.match(pattern, self.shortcode_name):
+        if not pattern.match(self.shortcode_name):
             raise ValueError(
                 "The shortcode_name attribute must use upper or lower case letters or digits and cannot contain spaces"
             )

--- a/wagtail_wordpress_import/handle_inline_shortcodes.py
+++ b/wagtail_wordpress_import/handle_inline_shortcodes.py
@@ -1,0 +1,53 @@
+import re
+
+
+class InlineShortcodeHandler:
+    """Subclasses should declare a shortcode_name and provide
+    a construct_html_tag method for converting the shortcode to a HTML tag.
+    """
+
+    inline_shortcode_name: str
+
+    element_name = "span"
+
+    def __init__(self):
+        # Subclasses should declare a shortcode_name
+        if not hasattr(self, "shortcode_name"):
+            raise NotImplementedError(
+                "Create a subclass of BlockShortcodeHandler with a shortcode_name attribute"
+            )
+        pattern = re.compile(r"^\S[a-zA-Z0-9_\S]+\S$")
+        # shortcode_name must use upper or lower case letters or digits and cannot contain spaces
+        if not re.match(pattern, self.shortcode_name):
+            raise ValueError(
+                "The shortcode_name attribute must use upper or lower case letters or digits and cannot contain spaces"
+            )
+
+    @property
+    def _pattern(self):
+        """Return a regex to match an inline shortcode and capture the attrs.
+
+        Given an input:
+
+            "Preface [foo bar=1] epilogue."
+
+        the regex will match the string between the "[" and "]"  tags. The
+        capture group "attrs" will match " bar=1", and capture group "shortcodename" will
+        match "foo".
+        \[(\S+)(?:\s)(\w\S.+)\]
+        """
+
+        return re.compile(
+            r"\["  # matches the opening [
+            + self.shortcode_name
+            + r"(?:\s)"  # matches a single space
+            + r"(?P<attrs>[^\]]*)"  # capture 'attrs', matching anything but ]
+            + r"\]"  # matches the closing ] of the opening tag
+        )
+
+    @staticmethod
+    def get_shortcode_attrs(string):
+        """Create and return a dict of the attrs of a shortcode."""
+        attrs = string.split(" ")
+        attrs = [attr.split("=") for attr in attrs]
+        return {attr[0]: attr[1].replace('"', "") for attr in attrs}

--- a/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
@@ -1,0 +1,44 @@
+from re import Match
+from django.test import TestCase
+
+from wagtail_wordpress_import.handle_inline_shortcodes import InlineShortcodeHandler
+
+
+class TestInlineShortcodeHandler(TestCase):
+    def test_regex_has_matches(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+            def construct_html_tag(self, html):
+                return self._pattern.finditer(html)
+
+        handler = FooHandler()
+        html = """[foo bar="1"]
+        [bar foo="1"]"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(sum(1 for _ in out), 1)
+
+    def test_regex_has_no_matches(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "nomatch"
+
+            def construct_html_tag(self, html):
+                return self._pattern.finditer(html)
+
+        handler = FooHandler()
+        html = """[foo bar="1"]
+        [bar foo="1"]"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(sum(1 for _ in out), 0)
+
+    def test_get_shortcode_attrs(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        attrs = 'foo="1" bar="2"'
+
+        attrs = handler.get_shortcode_attrs(attrs)
+        self.assertEqual(attrs, {"foo": "1", "bar": "2"})

--- a/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
@@ -1,4 +1,3 @@
-from re import Match
 from django.test import TestCase
 
 from wagtail_wordpress_import.handle_inline_shortcodes import InlineShortcodeHandler
@@ -33,6 +32,97 @@ class TestInlineShortcodeHandler(TestCase):
         out = handler.construct_html_tag(html)
         self.assertEqual(sum(1 for _ in out), 0)
 
+    def test_regex_mathes_adjacent_first_place(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+            def construct_html_tag(self, html):
+                return self._pattern.finditer(html)
+
+        handler = FooHandler()
+        html = """[foo bar="1"][bar foo="1"]"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(sum(1 for _ in out), 1)
+
+    def test_regex_mathes_adjacent_content_between(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "bar"
+
+            def construct_html_tag(self, html):
+                return self._pattern.finditer(html)
+
+        handler = FooHandler()
+        html = """[foo bar="1"]content between[bar foo="1"]"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(sum(1 for _ in out), 1)
+
+    def test_regex_mathes_adjacent_content_around(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "bar"
+
+            def construct_html_tag(self, html):
+                return self._pattern.finditer(html)
+
+        handler = FooHandler()
+        html = """content before[foo bar="1"][bar foo="1"]content after"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(sum(1 for _ in out), 1)
+
+
+class TestInlineShortcodeHandlerDocumentedExample(TestCase):
+    def test_construct_html_tag_documented_example(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+            def construct_html_tag(self, html):
+                matches = self._pattern.finditer(html)
+                for match in matches:
+                    attrs = self.get_shortcode_attrs(match.groupdict()["attrs"])
+                    html = html.replace(
+                        match.group(),
+                        f'<{self.element_name} data-{self.shortcode_name}="{attrs["symbol"]}">${attrs["symbol"]}</{self.element_name}>',
+                    )
+
+                return html
+
+        handler = FooHandler()
+        html = """some content before [foo symbol="ABC"] some content after"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(
+            out,
+            'some content before <span data-foo="ABC">$ABC</span> some content after',
+        )
+
+    def test_construct_html_tag_documented_example_ignores_bar(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+            def construct_html_tag(self, html):
+                matches = self._pattern.finditer(html)
+                for match in matches:
+                    attrs = self.get_shortcode_attrs(match.groupdict()["attrs"])
+                    html = html.replace(
+                        match.group(),
+                        f'<{self.element_name} data-{self.shortcode_name}="{attrs["symbol"]}">${attrs["symbol"]}</{self.element_name}>',
+                    )
+
+                return html
+
+        handler = FooHandler()
+        html = """some content before [foo symbol="ABC"] some content after [bar baz="foo"]"""
+
+        out = handler.construct_html_tag(html)
+        self.assertEqual(
+            out,
+            'some content before <span data-foo="ABC">$ABC</span> some content after [bar baz="foo"]',
+        )
+
+
+class TestGetAttrs(TestCase):
     def test_get_shortcode_attrs(self):
         class FooHandler(InlineShortcodeHandler):
             shortcode_name = "foo"
@@ -52,3 +142,27 @@ class TestInlineShortcodeHandler(TestCase):
 
         attrs = handler.get_shortcode_attrs(attrs)
         self.assertEqual(attrs, {"foo": "1", "bar": "2"})
+
+    def test_get_shortcode_attrs_no_quotes(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        attrs = "foo=1 bar=2"
+
+        attrs = handler.get_shortcode_attrs(attrs)
+        self.assertEqual(attrs, {"foo": "1", "bar": "2"})
+
+    def test_get_shortcode_attrs_extra_spacing(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        attrs = " foo=1  bar=2 "
+
+        with self.subTest(
+            """The provided method cannot handle multiple spaces around
+            the attrs or multiple space between the attrs"""
+        ):
+            with self.assertRaises(IndexError):
+                attrs = handler.get_shortcode_attrs(attrs)

--- a/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_inline_shortcode_handlers.py
@@ -42,3 +42,13 @@ class TestInlineShortcodeHandler(TestCase):
 
         attrs = handler.get_shortcode_attrs(attrs)
         self.assertEqual(attrs, {"foo": "1", "bar": "2"})
+
+    def test_get_shortcode_attrs_missing_quotes(self):
+        class FooHandler(InlineShortcodeHandler):
+            shortcode_name = "foo"
+
+        handler = FooHandler()
+        attrs = 'foo="1" bar=2'
+
+        attrs = handler.get_shortcode_attrs(attrs)
+        self.assertEqual(attrs, {"foo": "1", "bar": "2"})


### PR DESCRIPTION
# Add Inline Shortcode Handling

Provide a full example of adding an inline shortcode to be processed and be available for editing inside the Draftail editor.

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/67

---

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] This PR adds or updates documentation
