### PR TITLE
Refactor fetch_url and extend tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,14 +46,12 @@ setup(
         "bleach>=4.1,<4.2",
         "prettytable>=2.2,<2.3",
         "shortcodes>=5.1,<6.0",
-        "responses>=0.16.0,<0.17.0",
-        "requests>=2.26.0,<2.27.0",
-        "pillow>=8.4.0,<8.5.0",
     ],
     extras_require={
         "testing": [
             "dj-database-url==0.5.0",
             "freezegun==0.3.15",
+            "responses>=0.16.0,<0.17.0",
         ],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,14 @@ setup(
         "bleach>=4.1,<4.2",
         "prettytable>=2.2,<2.3",
         "shortcodes>=5.1,<6.0",
+        "responses>=0.16.0,<0.17.0",
+        "requests>=2.26.0,<2.27.0",
+        "pillow>=8.4.0,<8.5.0",
     ],
     extras_require={
         "testing": [
             "dj-database-url==0.5.0",
             "freezegun==0.3.15",
-            "responses==0.16.0",
-            "requests==2.26.0",
         ],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,12 @@ setup(
         "shortcodes>=5.1,<6.0",
     ],
     extras_require={
-        "testing": ["dj-database-url==0.5.0", "freezegun==0.3.15"],
+        "testing": [
+            "dj-database-url==0.5.0",
+            "freezegun==0.3.15",
+            "responses==0.16.0",
+            "requests==2.26.0",
+        ],
     },
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}
+envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}-requests{2.26.0}-responses{0.16.0}
 
 [flake8]
 # E501: Line too long
@@ -35,6 +35,8 @@ deps =
     prettytable: prettytable>=2.2,<2.3
     postgres: psycopg2>=2.8,<2.9
     shortcodes: shortcodes>=5.1,<6.0
+    responses: responses>=0.16.0,<0.17.0
+    requests: requests>=2.26.0,<2.27.0
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_wordpress_import}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}-requests{2.26.0}-responses{0.16.0}
+envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -35,8 +35,6 @@ deps =
     prettytable: prettytable>=2.2,<2.3
     postgres: psycopg2>=2.8,<2.9
     shortcodes: shortcodes>=5.1,<6.0
-    responses: responses>=0.16.0,<0.17.0
-    requests: requests>=2.26.0,<2.27.0
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_wordpress_import}

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     prettytable: prettytable>=2.2,<2.3
     postgres: psycopg2>=2.8,<2.9
     shortcodes: shortcodes>=5.1,<6.0
+    responses: responses>=0.16.0,<0.17.0
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_wordpress_import}

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -238,16 +238,16 @@ def get_or_save_image(src):
 def fetch_url(src, r=None, status=False, content_type=None):
     """general purpose url fetcher with ability to pass in own config"""
     try:
-        r = requests.get(src, **conf_get_requests_settings())
-        status = r.status_code == 200
+        response = requests.get(src, **conf_get_requests_settings())
+        status = True if response.status_code == 200 else False
         content_type = (
-            r.headers["content-type"].lower() if r.headers.get("content-type") else ""
+            response.headers["content-type"].lower()
+            if response.headers.get("content-type")
+            else ""
         )
-    except requests.ConnectTimeout:
-        print(f"CONNECTION TIMEOUT: {src}")
-    except requests.ConnectionError:
-        print(f"CONNECTION ERROR: {src}")
-    return r, status, content_type
+        return response, status, content_type
+    except Exception as e:
+        raise requests.ConnectionError(e)
 
 
 def get_absolute_src(src, domain_prefix=None):

--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -28,7 +28,7 @@ class BlockShortcodeHandler:
 
     shortcode_name: str
 
-    is_top_level_html_tag: True
+    is_top_level_html_tag = True
 
     def __init__(self):
         # Subclasses should declare a shortcode_name
@@ -93,10 +93,6 @@ class BlockShortcodeHandler:
     @property
     def element_name(self):
         return f"wagtail_block_{self.shortcode_name}"
-
-    @property
-    def is_top_level_html_tag(self):
-        return self.is_top_level_html_tag
 
 
 # Subclasses should declare a shortcode_name and provide

--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -28,7 +28,7 @@ class BlockShortcodeHandler:
 
     shortcode_name: str
 
-    top_level_html_tag: True
+    is_top_level_html_tag: True
 
     def __init__(self):
         # Subclasses should declare a shortcode_name
@@ -96,9 +96,7 @@ class BlockShortcodeHandler:
 
     @property
     def is_top_level_html_tag(self):
-        if not type(self.top_level_html_tag) == bool:
-            return True
-        return self.top_level_html_tag
+        return self.is_top_level_html_tag
 
 
 # Subclasses should declare a shortcode_name and provide

--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -28,7 +28,7 @@ class BlockShortcodeHandler:
 
     shortcode_name: str
 
-    is_top_level_html_tag: True
+    top_level_html_tag: True
 
     def __init__(self):
         # Subclasses should declare a shortcode_name
@@ -96,7 +96,9 @@ class BlockShortcodeHandler:
 
     @property
     def is_top_level_html_tag(self):
-        return self.is_top_level_html_tag
+        if not type(self.top_level_html_tag) == bool:
+            return True
+        return self.top_level_html_tag
 
 
 # Subclasses should declare a shortcode_name and provide

--- a/wagtail_wordpress_import/test/fixtures/raw_html.txt
+++ b/wagtail_wordpress_import/test/fixtures/raw_html.txt
@@ -1,23 +1,23 @@
 <!-- BE CAREFUL WHEN ALTERING THIS FIXTURE AS THE ORDER OF TAG MATTERS -->
-<img src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" alt="">
+<img src="https://www.example.com/images/bruno-4-runner.jpg" alt="">
 
 <span style="font-weight: bold;font-style:italic;">Lorem ipsum (xcounterx) dolor sit amet</span>
 
 <a href="#ideas"><strong>Lorem ipsum dolor sit (xcounterx) amet!</strong></a>
-<a href="https://www.budgetsaresexy.com/files/personal-finance-culminating-assignment.pdf">Read this</a>
+<a href="https://www.example.com/files/personal-finance-culminating-assignment.pdf">Read this</a>
 <h1><strong>Lorem ipsum dolor sit amet?</strong></h1>
 
 <p>Absolute image url.
     <a href="#">
-        <img src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" alt="">
+        <img src="https://www.example.com/images/bruno-4-runner.jpg" alt="">
     </a>
 </p>
 
-<p><wagtail_block_caption align="aligncenter" id="attachment_46162" width="600"><img alt="living the life financially independent" class="wp-image-46162 size-full" height="338" src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" width="600"/> <i>[Crossing a river with Bruno (our Toyota 4Runner) in <a href="http://freedomwithbruno.com/arrival-to-costa-rica/" rel="noopener noreferrer" target="_blank">Costa Rica</a>!]</i></wagtail_block_caption></p>
-<wagtail_block_caption align="aligncenter" id="attachment_46162" width="600"><img alt="living the life financially independent" class="wp-image-46162 size-full" height="338" src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" width="600"/> <i>[Crossing a river with Bruno (our Toyota 4Runner) in <a href="http://freedomwithbruno.com/arrival-to-costa-rica/" rel="noopener noreferrer" target="_blank">Costa Rica</a>!]</i></wagtail_block_caption>
+<p><wagtail_block_caption align="aligncenter" id="attachment_46162" width="600"><img alt="living the life financially independent" class="wp-image-46162 size-full" height="338" src="https://www.example.com/images/bruno-4-runner.jpg" width="600"/> <i>[Crossing a river with Bruno (our Toyota 4Runner) in <a href="http://freedomwithbruno.com/arrival-to-costa-rica/" rel="noopener noreferrer" target="_blank">Costa Rica</a>!]</i></wagtail_block_caption></p>
+<wagtail_block_caption align="aligncenter" id="attachment_46162" width="600"><img alt="living the life financially independent" class="wp-image-46162 size-full" height="338" src="https://www.example.com/images/bruno-4-runner.jpg" width="600"/> <i>[Crossing a river with Bruno (our Toyota 4Runner) in <a href="http://freedomwithbruno.com/arrival-to-costa-rica/" rel="noopener noreferrer" target="_blank">Costa Rica</a>!]</i></wagtail_block_caption>
 <p>Absolute image url.
     <a href="#">
-        <img src="https://www.budgetsaresexy.com/images/bruno-4-runner.jpg" alt="">
+        <img src="https://www.example.com/images/bruno-4-runner.jpg" alt="">
     </a>
 </p>
 <ul>

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -167,7 +167,7 @@ class TestBlockBuilderBuild(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/bruno-4-runner.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -231,7 +231,7 @@ class TestRichTextImageLinking(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/bruno-4-runner.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -256,7 +256,7 @@ class TestRichTextImageLinking(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/bruno-4-runner.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -281,7 +281,7 @@ class TestRichTextImageLinking(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/bruno-4-runner.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -361,12 +361,12 @@ class TestBlockBuilderFetchUrlRequests(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/bruno-4-runner.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
         response, status, content_type = fetch_url(url_to_fetch)
-        self.assertTrue(response.content.startswith(b"\x89PNG"))
+        self.assertTrue(response.content.startswith(b"\xff\xd8"))
         self.assertTrue(status)
         self.assertTrue("image/jpeg" in content_type)
 

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -1,11 +1,9 @@
 import os
-import tempfile
 
 import bs4
 import responses
 from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
-from PIL import Image
 from wagtail.images import get_image_model
 from wagtail_wordpress_import.block_builder import BlockBuilder, conf_promote_child_tags
 from wagtail_wordpress_import.block_builder_defaults import (
@@ -22,37 +20,14 @@ from wagtail_wordpress_import.block_builder_defaults import (
     get_image_file_name,
     image_linker,
 )
+from wagtail_wordpress_import.test.tests.utility_functions import (
+    get_soup,
+    mock_image,
+    mock_pdf,
+)
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
 FIXTURES_PATH = BASE_PATH + "/fixtures"
-
-
-def get_soup(html, parser):
-    soup = BeautifulSoup(html, parser)
-    return soup
-
-
-def mock_image():
-    temp_file = tempfile.NamedTemporaryFile(suffix=".jpg")
-    image = Image.new("RGB", (200, 200), "white")
-    image.save(temp_file, "PNG")
-    return open(temp_file.name, mode="rb")
-
-
-def mock_pdf():
-    temp_file = tempfile.NamedTemporaryFile(suffix=".pdf")
-    temp_file.write(b"PDF Document")
-    return open(temp_file.name, mode="rb")
-
-
-class TestFixtures(TestCase):
-    def test_mock_image(self):
-        image_content = mock_image().read()
-        self.assertTrue(image_content.startswith(b"\x89PNG"))
-
-    def test_mock_pdf(self):
-        pdf_content = mock_pdf().read()
-        self.assertEqual(pdf_content, b"PDF Document")
 
 
 class TestBlockBuilderRemoveParents(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -2,6 +2,7 @@ import os
 
 import bs4
 import responses
+import requests
 from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
 from wagtail.images import get_image_model
@@ -379,6 +380,6 @@ class TestBlockBuilderFetchUrlRequests(TestCase):
             "https://www.example.com/images/connection_error.jpg",
             body=Exception("Connection error"),
         )
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(requests.ConnectionError) as ctx:
             fetch_url(url_to_fetch)
         self.assertTrue("Connection error" in str(ctx.exception))

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -240,10 +240,18 @@ class TestRichTextImageLinking(TestCase):
         image = get_image_model().objects.get(title="bruno-4-runner.jpg")
         soup = BeautifulSoup(output, "html.parser")
         embed_tag = soup.find("embed")
-        self.assertEqual(embed_tag.attrs["id"], str(image.id))
-        self.assertEqual(embed_tag.attrs["embedtype"], "image")
-        self.assertEqual(embed_tag.attrs["format"], "fullwidth")
-        self.assertEqual(embed_tag.attrs["alt"], "bruno 4 runner")
+
+        with self.subTest("embed tag attr 'id' has the correct ID"):
+            self.assertEqual(embed_tag.attrs["id"], str(image.id))
+
+        with self.subTest("embed tag attr 'embedtype' has the correct type"):
+            self.assertEqual(embed_tag.attrs["embedtype"], "image")
+
+        with self.subTest("embed tag attr 'format' has correct style format"):
+            self.assertEqual(embed_tag.attrs["format"], "fullwidth")
+
+        with self.subTest("embed tag attr 'alt' has correct content"):
+            self.assertEqual(embed_tag.attrs["alt"], "bruno 4 runner")
 
     @responses.activate
     def test_embed_tag_generated_class_align_left(self):

--- a/wagtail_wordpress_import/test/tests/test_import_hooks_items.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks_items.py
@@ -124,6 +124,11 @@ class TestImportHooksXmlItemPersisted(TestCase):
 
         # Values of the first item in the ItemsCache instance foo attribute
         foo = cache.foo[0]
+
+        # there should be no wp:postmeta in the cache
+        with self.assertRaises(KeyError):
+            foo["wp:postmeta"]
+
         self.assertEqual(foo["title"], "foo-item")
         self.assertEqual(foo["link"], "https://www.example.com/foo-item/")
         self.assertEqual(foo["pubDate"], "Tue, 13 Jul 2010 16:16:46 +0000")
@@ -140,18 +145,23 @@ class TestImportHooksXmlItemPersisted(TestCase):
         self.assertEqual(len(cache.bar), 1)
 
         # Values of the first item in the ItemsCache instance bar attribute
-        foo = cache.bar[0]
-        self.assertEqual(foo["title"], "bar-item")
-        self.assertEqual(foo["link"], "https://www.example.com/bar-item/")
-        self.assertEqual(foo["pubDate"], "Tue, 13 Jul 2010 16:16:46 +0000")
-        self.assertEqual(foo["guid"], "https://www.example.com/bar.jpg")
-        self.assertEqual(foo["wp:post_id"], 200)
-        self.assertEqual(foo["wp:post_date"], "2010-07-13 12:16:46")
-        self.assertEqual(foo["wp:post_date_gmt"], "2010-07-13 16:16:46")
-        self.assertEqual(foo["wp:post_modified"], "2010-07-13 12:16:46")
-        self.assertEqual(foo["wp:post_modified_gmt"], "2010-07-13 16:16:46")
-        self.assertEqual(foo["wp:post_name"], "bar-item")
-        self.assertEqual(foo["wp:post_type"], "bar")
+        bar = cache.bar[0]
+
+        # there should be no wp:postmeta in the cache
+        with self.assertRaises(KeyError):
+            bar["wp:postmeta"]
+
+        self.assertEqual(bar["title"], "bar-item")
+        self.assertEqual(bar["link"], "https://www.example.com/bar-item/")
+        self.assertEqual(bar["pubDate"], "Tue, 13 Jul 2010 16:16:46 +0000")
+        self.assertEqual(bar["guid"], "https://www.example.com/bar.jpg")
+        self.assertEqual(bar["wp:post_id"], 200)
+        self.assertEqual(bar["wp:post_date"], "2010-07-13 12:16:46")
+        self.assertEqual(bar["wp:post_date_gmt"], "2010-07-13 16:16:46")
+        self.assertEqual(bar["wp:post_modified"], "2010-07-13 12:16:46")
+        self.assertEqual(bar["wp:post_modified_gmt"], "2010-07-13 16:16:46")
+        self.assertEqual(bar["wp:post_name"], "bar-item")
+        self.assertEqual(bar["wp:post_type"], "bar")
 
 
 class WordpressImporterTestsCheckXmlItemsNotCached(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -9,6 +9,7 @@ from wagtail_wordpress_import.prefilters.handle_shortcodes import (
     CaptionHandler,
     register,
 )
+from wagtail_wordpress_import.test.tests.utility_functions import mock_image
 
 
 class TestBlockShortcodeRegex(TestCase):
@@ -275,6 +276,19 @@ class TestIncludedShortcodeHandlers(TestCase):
         self.assertEqual(len(SHORTCODE_HANDLERS), 2)
 
 
+class TestIncludedShortcodeIsTopLevel(TestCase):
+    def test_is_top_level_html_tag(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+            custom_html_tag_prefix = "wagtail_block_"
+            # change the class attribute
+            is_top_level_html_tag = False
+
+        foo = FooHandler()
+        is_top_level_html_tag = foo.is_top_level_html_tag
+        self.assertEqual(is_top_level_html_tag, False)
+
+
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):
     @responses.activate
     def test_construct_block_method_output(self):
@@ -313,3 +327,133 @@ class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):
         )
         self.assertEqual(json["value"]["alignment"], "center")
         self.assertEqual(json["value"]["link"], "https//www.example.com/bar/")
+
+
+class TestCaptionHandler(TestCase):
+    @responses.activate
+    def test_absence_of_image(self):
+        handler = CaptionHandler()
+        responses.add(
+            responses.GET,
+            "https://www.example.com/images/foo.jpg",
+            body=mock_image(),
+            status=200,
+            content_type="image/jpeg",
+        )
+        wagtail_custom_html = """
+        <wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
+            <a href="http://www.example.com/">
+                
+            </a>This is a caption about the image
+        </wagtail_block_caption>"""
+
+        output = handler.construct_block(
+            BeautifulSoup(wagtail_custom_html, "html.parser").find(
+                f"wagtail_block_{handler.shortcode_name}"
+            )
+        )
+        # The image is not present in the html, the output should be a raw_html block
+        self.assertEqual(output["type"], "raw_html")
+        self.assertTrue("No image found in caption" in output["value"])
+
+    @responses.activate
+    def test_construct_block_method_output(self):
+        handler = CaptionHandler()
+        responses.add(
+            responses.GET,
+            "https://www.example.com/images/foo.jpg",
+            body=mock_image(),
+            status=200,
+            content_type="image/jpeg",
+        )
+        wagtail_custom_html = """
+        <wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
+            <a href="http://www.example.com/">
+                <img
+                    class="wp-image-46162 size-full" 
+                    src="https://www.example.com/images/foo.jpg" 
+                    alt="This describes the image" 
+                    width="600" 
+                    height="338" />
+            </a>This is a caption about the image
+        </wagtail_block_caption>"""
+        output = handler.construct_block(
+            BeautifulSoup(wagtail_custom_html, "html.parser").find(
+                f"wagtail_block_{handler.shortcode_name}"
+            )
+        )
+        self.assertEqual(output["type"], "image")
+        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(
+            output["value"]["caption"], "This is a caption about the image"
+        )
+        self.assertEqual(output["value"]["alignment"], "center")
+        self.assertEqual(output["value"]["link"], "http://www.example.com/")
+
+    @responses.activate
+    def test_absence_of_alignment(self):
+        handler = CaptionHandler()
+        responses.add(
+            responses.GET,
+            "https://www.example.com/images/foo.jpg",
+            body=mock_image(),
+            status=200,
+            content_type="image/jpeg",
+        )
+        wagtail_custom_html = """
+        <wagtail_block_caption id="attachment_46162" width="600">
+            <a href="http://www.example.com/">
+                <img
+                    class="wp-image-46162 size-full"
+                    src="https://www.example.com/images/foo.jpg"
+                    alt="This describes the image"
+                    width="600"
+                    height="338" />
+            </a>This is a caption about the image
+        </wagtail_block_caption>"""
+
+        output = handler.construct_block(
+            BeautifulSoup(wagtail_custom_html, "html.parser").find(
+                f"wagtail_block_{handler.shortcode_name}"
+            )
+        )
+        self.assertEqual(output["type"], "image")
+        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(
+            output["value"]["caption"], "This is a caption about the image"
+        )
+        self.assertEqual(output["value"]["alignment"], "left")
+        self.assertEqual(output["value"]["link"], "http://www.example.com/")
+
+    @responses.activate
+    def test_absence_of_an_anchor(self):
+        handler = CaptionHandler()
+        responses.add(
+            responses.GET,
+            "https://www.example.com/images/foo.jpg",
+            body=mock_image(),
+            status=200,
+            content_type="image/jpeg",
+        )
+        wagtail_custom_html = """
+        <wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
+                <img
+                    class="wp-image-46162 size-full" 
+                    src="https://www.example.com/images/foo.jpg" 
+                    alt="This describes the image" 
+                    width="600" 
+                    height="338" />
+            This is a caption about the image
+        </wagtail_block_caption>"""
+        output = handler.construct_block(
+            BeautifulSoup(wagtail_custom_html, "html.parser").find(
+                f"wagtail_block_{handler.shortcode_name}"
+            )
+        )
+        self.assertEqual(output["type"], "image")
+        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(
+            output["value"]["caption"], "This is a caption about the image"
+        )
+        self.assertEqual(output["value"]["alignment"], "center")
+        self.assertEqual(output["value"]["link"], "")

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -1,9 +1,7 @@
-import unittest
 from bs4 import BeautifulSoup
 from django.test import TestCase
-from PIL import Image
-import tempfile
 import responses
+from wagtail_wordpress_import.test.tests.utility_functions import mock_image
 
 from wagtail_wordpress_import.prefilters.handle_shortcodes import (
     SHORTCODE_HANDLERS,
@@ -11,13 +9,6 @@ from wagtail_wordpress_import.prefilters.handle_shortcodes import (
     CaptionHandler,
     register,
 )
-
-
-def mock_image():
-    temp_file = tempfile.NamedTemporaryFile(suffix=".jpg")
-    image = Image.new("RGB", (200, 200), "white")
-    image.save(temp_file, "PNG")
-    return open(temp_file.name, mode="rb")
 
 
 class TestBlockShortcodeRegex(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -275,17 +275,26 @@ class TestIncludedShortcodeHandlers(TestCase):
         self.assertEqual(len(SHORTCODE_HANDLERS), 2)
 
 
-class TestIncludedShortcodeIsTopLevel(TestCase):
-    def test_is_top_level_html_tag(self):
+class TestProvidedShortcodeIsTopLevel(TestCase):
+    """
+    Block Shortcode Handler has a is_top_level_html_tag property that is True by default.
+    It can be set to False to indicate that the shortcode is not a top level HTML tag.
+    """
+
+    def test_is_top_level_html_tag_defaults_to_true(self):
         class FooHandler(BlockShortcodeHandler):
             shortcode_name = "foo"
-            custom_html_tag_prefix = "wagtail_block_"
-            # change the class attribute
+
+        foo = FooHandler()
+        self.assertTrue(foo.is_top_level_html_tag)
+
+    def test_is_top_level_html_tag_can_be_overridden(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
             is_top_level_html_tag = False
 
         foo = FooHandler()
-        is_top_level_html_tag = foo.is_top_level_html_tag
-        self.assertEqual(is_top_level_html_tag, False)
+        self.assertFalse(foo.is_top_level_html_tag)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -354,13 +354,11 @@ class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):
         json = handler.construct_block(
             wagtail_custom_html.find("wagtail_block_caption")
         )
+        image = get_image_model().objects.get(title="j-money-family-portrait.jpg")
+
         self.assertIsInstance(json, dict)
         self.assertEqual(json["type"], "image")
-        # ["value"]["image"] is an image id. it should be returned as an integer but we cannot
-        # reply on the value returned here so check if it is an integer.
-        # there is a ticket to improve testing when fetching remote images:
-        # https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/76
-        self.assertIsInstance(int(json["value"]["image"]), int)
+        self.assertEqual(json["value"]["image"], image.id)
         self.assertEqual(
             json["value"]["caption"],
             "[This is a caption about the image (the one above) in Glorious Rich Text!]",

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -275,17 +275,58 @@ class TestIncludedShortcodeHandlers(TestCase):
         self.assertEqual(len(SHORTCODE_HANDLERS), 2)
 
 
-class TestIncludedShortcodeIsTopLevel(TestCase):
-    def test_is_top_level_html_tag(self):
+class TestProvidedShortcodeIsTopLevel(TestCase):
+    """
+    Block Shortcode Handler has a top_level_property that is True by default.
+    It can be set to False to indicate that the shortcode is not a top level html tag.
+
+    There are tests here to ensure that none boolean values will return True.
+    """
+
+    def test_is_top_level_html_tag_value_false(self):
         class FooHandler(BlockShortcodeHandler):
             shortcode_name = "foo"
             custom_html_tag_prefix = "wagtail_block_"
-            # change the class attribute
-            is_top_level_html_tag = False
+            top_level_html_tag = False
 
         foo = FooHandler()
-        is_top_level_html_tag = foo.is_top_level_html_tag
-        self.assertEqual(is_top_level_html_tag, False)
+        self.assertFalse(foo.is_top_level_html_tag)
+
+    def test_is_top_level_html_tag_value_string(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+            custom_html_tag_prefix = "wagtail_block_"
+            top_level_html_tag = "bar"
+
+        foo = FooHandler()
+        self.assertTrue(foo.is_top_level_html_tag)
+
+    def test_is_top_level_html_tag_value_none(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+            custom_html_tag_prefix = "wagtail_block_"
+            top_level_html_tag = None
+
+        foo = FooHandler()
+        self.assertTrue(foo.is_top_level_html_tag)
+
+    def test_is_top_level_html_tag_value_list(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+            custom_html_tag_prefix = "wagtail_block_"
+            top_level_html_tag = ["foo", "bar"]
+
+        foo = FooHandler()
+        self.assertTrue(foo.is_top_level_html_tag)
+
+    def test_is_top_level_html_tag_value_dict(self):
+        class FooHandler(BlockShortcodeHandler):
+            shortcode_name = "foo"
+            custom_html_tag_prefix = "wagtail_block_"
+            top_level_html_tag = {"foo": "bar"}
+
+        foo = FooHandler()
+        self.assertTrue(foo.is_top_level_html_tag)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -275,58 +275,17 @@ class TestIncludedShortcodeHandlers(TestCase):
         self.assertEqual(len(SHORTCODE_HANDLERS), 2)
 
 
-class TestProvidedShortcodeIsTopLevel(TestCase):
-    """
-    Block Shortcode Handler has a top_level_property that is True by default.
-    It can be set to False to indicate that the shortcode is not a top level html tag.
-
-    There are tests here to ensure that none boolean values will return True.
-    """
-
-    def test_is_top_level_html_tag_value_false(self):
+class TestIncludedShortcodeIsTopLevel(TestCase):
+    def test_is_top_level_html_tag(self):
         class FooHandler(BlockShortcodeHandler):
             shortcode_name = "foo"
             custom_html_tag_prefix = "wagtail_block_"
-            top_level_html_tag = False
+            # change the class attribute
+            is_top_level_html_tag = False
 
         foo = FooHandler()
-        self.assertFalse(foo.is_top_level_html_tag)
-
-    def test_is_top_level_html_tag_value_string(self):
-        class FooHandler(BlockShortcodeHandler):
-            shortcode_name = "foo"
-            custom_html_tag_prefix = "wagtail_block_"
-            top_level_html_tag = "bar"
-
-        foo = FooHandler()
-        self.assertTrue(foo.is_top_level_html_tag)
-
-    def test_is_top_level_html_tag_value_none(self):
-        class FooHandler(BlockShortcodeHandler):
-            shortcode_name = "foo"
-            custom_html_tag_prefix = "wagtail_block_"
-            top_level_html_tag = None
-
-        foo = FooHandler()
-        self.assertTrue(foo.is_top_level_html_tag)
-
-    def test_is_top_level_html_tag_value_list(self):
-        class FooHandler(BlockShortcodeHandler):
-            shortcode_name = "foo"
-            custom_html_tag_prefix = "wagtail_block_"
-            top_level_html_tag = ["foo", "bar"]
-
-        foo = FooHandler()
-        self.assertTrue(foo.is_top_level_html_tag)
-
-    def test_is_top_level_html_tag_value_dict(self):
-        class FooHandler(BlockShortcodeHandler):
-            shortcode_name = "foo"
-            custom_html_tag_prefix = "wagtail_block_"
-            top_level_html_tag = {"foo": "bar"}
-
-        foo = FooHandler()
-        self.assertTrue(foo.is_top_level_html_tag)
+        is_top_level_html_tag = foo.is_top_level_html_tag
+        self.assertEqual(is_top_level_html_tag, False)
 
 
 class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -1,8 +1,7 @@
+import responses
 from bs4 import BeautifulSoup
 from django.test import TestCase
-import responses
-from wagtail_wordpress_import.test.tests.utility_functions import mock_image
-
+from wagtail.images import get_image_model
 from wagtail_wordpress_import.prefilters.handle_shortcodes import (
     SHORTCODE_HANDLERS,
     BlockShortcodeHandler,
@@ -382,8 +381,9 @@ class TestCaptionHandler(TestCase):
                 f"wagtail_block_{handler.shortcode_name}"
             )
         )
+        image = get_image_model().objects.get(title="foo.jpg")
         self.assertEqual(output["type"], "image")
-        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(output["value"]["image"], image.id)
         self.assertEqual(
             output["value"]["caption"], "This is a caption about the image"
         )
@@ -417,8 +417,9 @@ class TestCaptionHandler(TestCase):
                 f"wagtail_block_{handler.shortcode_name}"
             )
         )
+        image = get_image_model().objects.get(title="foo.jpg")
         self.assertEqual(output["type"], "image")
-        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(output["value"]["image"], image.id)
         self.assertEqual(
             output["value"]["caption"], "This is a caption about the image"
         )
@@ -450,8 +451,9 @@ class TestCaptionHandler(TestCase):
                 f"wagtail_block_{handler.shortcode_name}"
             )
         )
+        image = get_image_model().objects.get(title="foo.jpg")
         self.assertEqual(output["type"], "image")
-        self.assertEqual(str(output["value"]["image"]), "1")
+        self.assertEqual(output["value"]["image"], image.id)
         self.assertEqual(
             output["value"]["caption"], "This is a caption about the image"
         )

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -294,7 +294,7 @@ class TestShortcodeHandlerStreamfieldBlockCreation(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/j-money-family-portrait.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -361,7 +361,7 @@ class TestCaptionHandler(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/foo.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -396,7 +396,7 @@ class TestCaptionHandler(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/foo.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )
@@ -432,7 +432,7 @@ class TestCaptionHandler(TestCase):
         responses.add(
             responses.GET,
             "https://www.example.com/images/foo.jpg",
-            body=mock_image(),
+            body=mock_image().read(),
             status=200,
             content_type="image/jpeg",
         )

--- a/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
+++ b/wagtail_wordpress_import/test/tests/test_shortcode_handlers.py
@@ -373,13 +373,6 @@ class TestCaptionHandler(TestCase):
     @responses.activate
     def test_absence_of_image(self):
         handler = CaptionHandler()
-        responses.add(
-            responses.GET,
-            "https://www.example.com/images/foo.jpg",
-            body=mock_image(),
-            status=200,
-            content_type="image/jpeg",
-        )
         wagtail_custom_html = """
         <wagtail_block_caption id="attachment_46162" align="aligncenter" width="600">
             <a href="http://www.example.com/">

--- a/wagtail_wordpress_import/test/tests/test_utility_functions.py
+++ b/wagtail_wordpress_import/test/tests/test_utility_functions.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from wagtail_wordpress_import.test.tests.utility_functions import (
+    mock_image,
+    mock_pdf,
+    get_soup,
+)
+
+
+class TestFixtures(TestCase):
+    def test_mock_image(self):
+        image_content = mock_image().read()
+        self.assertTrue(image_content.startswith(b"\x89PNG"))
+
+    def test_mock_pdf(self):
+        pdf_content = mock_pdf().read()
+        self.assertEqual(pdf_content, b"PDF Document")
+
+    def test_get_soup_html_parser(self):
+        soup = get_soup("<p>Hello</p>", "html.parser")
+        self.assertEqual(soup.p.text, "Hello")
+
+    def test_get_soup_html5lib(self):
+        soup = get_soup("<p>Hello</p>", "html5lib")
+        self.assertEqual(soup.p.text, "Hello")
+
+    def test_get_soup_lxml(self):
+        soup = get_soup("<p>Hello</p>", "lxml")
+        self.assertEqual(soup.p.text, "Hello")

--- a/wagtail_wordpress_import/test/tests/test_utility_functions.py
+++ b/wagtail_wordpress_import/test/tests/test_utility_functions.py
@@ -7,9 +7,16 @@ from wagtail_wordpress_import.test.tests.utility_functions import (
 
 
 class TestFixtures(TestCase):
+    def setUp(self):
+        self.image = mock_image()
+        self.pdf = mock_pdf()
+
     def test_mock_image(self):
-        image_content = mock_image().read()
-        self.assertTrue(image_content.startswith(b"\x89PNG"))
+        self.assertEqual(self.image.name, "test.jpg")
+
+    def test_mock_image_content(self):
+        image_content = self.image.read()
+        self.assertTrue(image_content.startswith(b"\xff\xd8"))
 
     def test_mock_pdf(self):
         pdf_content = mock_pdf().read()

--- a/wagtail_wordpress_import/test/tests/utility_functions.py
+++ b/wagtail_wordpress_import/test/tests/utility_functions.py
@@ -1,3 +1,4 @@
+import io
 import tempfile
 from PIL import Image
 from bs4 import BeautifulSoup
@@ -8,11 +9,13 @@ def get_soup(html, parser):
     return soup
 
 
-def mock_image():
-    temp_file = tempfile.NamedTemporaryFile(suffix=".png")
-    image = Image.new("RGB", (200, 200), "white")
-    image.save(temp_file, "PNG")
-    return open(temp_file.name, mode="rb")
+def mock_image(file_name="test.jpg", width=100, height=100, color="white"):
+    file = io.BytesIO()
+    image = Image.new("RGB", (width, height), color)
+    image.save(file, "JPEG")
+    file.name = file_name
+    file.seek(0)
+    return file
 
 
 def mock_pdf():

--- a/wagtail_wordpress_import/test/tests/utility_functions.py
+++ b/wagtail_wordpress_import/test/tests/utility_functions.py
@@ -1,0 +1,21 @@
+import tempfile
+from PIL import Image
+from bs4 import BeautifulSoup
+
+
+def get_soup(html, parser):
+    soup = BeautifulSoup(html, parser)
+    return soup
+
+
+def mock_image():
+    temp_file = tempfile.NamedTemporaryFile(suffix=".jpg")
+    image = Image.new("RGB", (200, 200), "white")
+    image.save(temp_file, "PNG")
+    return open(temp_file.name, mode="rb")
+
+
+def mock_pdf():
+    temp_file = tempfile.NamedTemporaryFile(suffix=".pdf")
+    temp_file.write(b"PDF Document")
+    return open(temp_file.name, mode="rb")

--- a/wagtail_wordpress_import/test/tests/utility_functions.py
+++ b/wagtail_wordpress_import/test/tests/utility_functions.py
@@ -9,7 +9,7 @@ def get_soup(html, parser):
 
 
 def mock_image():
-    temp_file = tempfile.NamedTemporaryFile(suffix=".jpg")
+    temp_file = tempfile.NamedTemporaryFile(suffix=".png")
     image = Image.new("RGB", (200, 200), "white")
     image.save(temp_file, "PNG")
     return open(temp_file.name, mode="rb")

--- a/wagtail_wordpress_import/test/tests/xml_boilerplate.py
+++ b/wagtail_wordpress_import/test/tests/xml_boilerplate.py
@@ -10,8 +10,8 @@ xml_stream_header = StringIO(
         <pubDate>Fri, 30 Jul 2021 11:56:01 +0000</pubDate>
         <language>en-US</language>
         <wp:wxr_version>1.2</wp:wxr_version>
-        <wp:base_site_url>https://www.budgetsaresexy.com</wp:base_site_url>
-        <wp:base_blog_url>https://www.budgetsaresexy.com</wp:base_blog_url>"""
+        <wp:base_site_url>https://www.example.com</wp:base_site_url>
+        <wp:base_blog_url>https://www.example.com</wp:base_blog_url>"""
 ).read()
 
 xml_stream_footer = StringIO(


### PR DESCRIPTION
# Implement the Responses Library

I have worked through any tests that needed to work with external site urls and implemented the responses library in those place. I've also add some extra tests that I felt needed to be done.

I made changes to the CaptionHandler().construct_block method so the tests are easier to implement as well as using responses library.

**There is one TODO** I added in the above method to implement logging for a case of a caption shortcode that has no `<img` tag. There's an [upcoming ticket](https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/63) to improve the logging. It's not a part of the process that will prevent an import continuing and adds a raw_html block with a helpful message thats not visible in the frontend by using HTML <!-- comment -->.

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/76

---

<!-- Please tick or remove these as relevant. Provide further details if valuable. Be pragmatic. -->

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: there are no changes to the usage of the package.
