### PR TITLE
Add command tests

### DIFF
--- a/wagtail_wordpress_import/management/commands/reduce_xml.py
+++ b/wagtail_wordpress_import/management/commands/reduce_xml.py
@@ -21,16 +21,9 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser):
-        parser.add_argument("xmlfile", type=str, help="The name of your xml file")
+        parser.add_argument("xml_file", type=str, help="The full path to your xml file")
 
     def get_xml_file(self, xml_file):
-        if "/" in xml_file:
-            self.stdout.write(
-                self.style.ERROR(
-                    f"Your xml file should be place in the root of your app: {xml_file}"
-                )
-            )
-            exit()
 
         if os.path.exists(xml_file):
             return xml_file
@@ -41,7 +34,7 @@ class Command(BaseCommand):
         exit()
 
     def handle(self, *args, **options):
-        file_path = self.get_xml_file(options["xmlfile"])
+        file_path = self.get_xml_file(options["xml_file"])
         self.stdout.write(self.style.WARNING("Reducing ..."))
         self.stdout.write(
             self.style.NOTICE(

--- a/wagtail_wordpress_import/test/tests/test_commands.py
+++ b/wagtail_wordpress_import/test/tests/test_commands.py
@@ -1,19 +1,80 @@
-from django.test import TestCase
+from unittest.mock import patch
+from django.test import TestCase, override_settings
+from django.core.management import call_command, CommandError
 from wagtail_wordpress_import.management.commands.import_xml import Command as RunCmd
 from wagtail_wordpress_import.management.commands.reduce_xml import Command as ReduceCmd
+from wagtail_wordpress_import.xml_boilerplate import (
+    build_xml_stream,
+    generate_temporay_file,
+)
 
 
-class TestRunXmlCommand(TestCase):
-    def setUp(self):
-        self.cmd = RunCmd()
+class TestImportXmlCommandNoConfig(TestCase):
+    def test_without_arguments(self):
+        with self.assertRaises(CommandError) as ctx:
+            call_command("import_xml")
+        self.assertEqual(
+            str(ctx.exception),
+            "Error: the following arguments are required: xml_file, parent_id",
+        )
 
-    def test_command(self):
-        self.assertIsInstance(self.cmd, RunCmd)
+    def test_with_only_xml_file_argument(self):
+        with self.assertRaises(CommandError) as ctx:
+            call_command("import_xml", "test.xml")
+        self.assertEqual(
+            str(ctx.exception),
+            "Error: the following arguments are required: parent_id",
+        )
+
+    def test_with_required_arguments(self):
+        with self.assertRaises(SystemExit):
+            call_command("import_xml", "test.xml", "2")
+
+
+@override_settings(
+    WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN="http://www.example.com",
+)
+class TestImportXmlCommandWithConfig(TestCase):
+    def test_xml_file_error(self):
+        # The XML file does not exist
+        with self.assertRaises(SystemExit):
+            call_command("import_xml", "test.xml", "2")
+
+    def test_run_with_xml_and_parent_id(self):
+        built_file = generate_temporay_file(
+            build_xml_stream(xml_tags_fragment="").read()
+        )
+
+        with self.assertRaises(FileNotFoundError):
+            # In testing there is no log folder
+            # the command should raise this as an error
+            call_command(
+                "import_xml", built_file, "2", "-a", "example", "-m", "TestPage"
+            )
 
 
 class TestReduceCommand(TestCase):
-    def setUp(self):
-        self.cmd = ReduceCmd()
+    def test_without_arguments(self):
+        with self.assertRaises(CommandError) as ctx:
+            call_command("reduce_xml")
+        self.assertEqual(
+            str(ctx.exception),
+            "Error: the following arguments are required: xml_file",
+        )
 
-    def test_command(self):
-        self.assertIsInstance(self.cmd, ReduceCmd)
+    def test_xml_file_error(self):
+        # The XML file does not exist
+        with self.assertRaises(SystemExit):
+            call_command("reduce_xml", "test.xml")
+
+    def test_get_xml_file(self):
+        cmd = ReduceCmd()
+        with self.assertRaises(SystemExit):
+            xml_file = cmd.get_xml_file("test.xml")
+        with self.assertRaises(SystemExit):
+            xml_file = cmd.get_xml_file("folder/test.xml")
+
+        built_file = generate_temporay_file(
+            build_xml_stream(xml_tags_fragment="").read()
+        )
+        self.assertEqual(built_file, cmd.get_xml_file(built_file))

--- a/wagtail_wordpress_import/test/tests/test_commands.py
+++ b/wagtail_wordpress_import/test/tests/test_commands.py
@@ -5,7 +5,7 @@ from wagtail_wordpress_import.management.commands.import_xml import Command as R
 from wagtail_wordpress_import.management.commands.reduce_xml import Command as ReduceCmd
 from wagtail_wordpress_import.xml_boilerplate import (
     build_xml_stream,
-    generate_temporay_file,
+    generate_temporary_file,
 )
 
 
@@ -41,7 +41,7 @@ class TestImportXmlCommandWithConfig(TestCase):
             call_command("import_xml", "test.xml", "2")
 
     def test_run_with_xml_and_parent_id(self):
-        built_file = generate_temporay_file(
+        built_file = generate_temporary_file(
             build_xml_stream(xml_tags_fragment="").read()
         )
 
@@ -74,7 +74,7 @@ class TestReduceCommand(TestCase):
         with self.assertRaises(SystemExit):
             xml_file = cmd.get_xml_file("folder/test.xml")
 
-        built_file = generate_temporay_file(
+        built_file = generate_temporary_file(
             build_xml_stream(xml_tags_fragment="").read()
         )
         self.assertEqual(built_file, cmd.get_xml_file(built_file))

--- a/wagtail_wordpress_import/test/tests/test_import_hooks_tags.py
+++ b/wagtail_wordpress_import/test/tests/test_import_hooks_tags.py
@@ -10,7 +10,7 @@ from wagtail_wordpress_import.importers.wordpress import WordpressImporter
 from wagtail_wordpress_import.logger import Logger
 from wagtail_wordpress_import.xml_boilerplate import (
     build_xml_stream,
-    generate_temporay_file,
+    generate_temporary_file,
 )
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
@@ -174,7 +174,7 @@ class WordpressImporterTestsCheckXmlTagsNotCached(TestCase):
             <wp:post_type>post</wp:post_type>
         </item>
         """
-        built_file = generate_temporay_file(
+        built_file = generate_temporary_file(
             build_xml_stream(xml_tags_fragment=fragment).read()
         )
 

--- a/wagtail_wordpress_import/xml_boilerplate.py
+++ b/wagtail_wordpress_import/xml_boilerplate.py
@@ -30,7 +30,7 @@ def build_xml_stream(xml_tags_fragment="", xml_items_fragment=""):
     )
 
 
-def generate_temporay_file(xml_stream):
+def generate_temporary_file(xml_stream):
 
     temp_file = tempfile.NamedTemporaryFile(delete=False)
 


### PR DESCRIPTION
# Add extra command tests

This work extends the tests for the `import_xml` and `reduce_xml` commands

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/95

The coverage is now at 82%. I think that once merged the coverage should be more than this because other work has also improved coveage.

---

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: nothing has change in it developer usage.
