### PR TITLE
Fix wp_post_meta content

### DIFF
--- a/wagtail_wordpress_import/functions.py
+++ b/wagtail_wordpress_import/functions.py
@@ -65,8 +65,13 @@ def snakecase_key(key):
 
 
 def get_attr_as_list(node, key):
-    if key in node:
-        if isinstance(node[key], dict):
-            return [node[key]]
-        return node[key]
-    return []
+    try:
+        if key in node:
+            if len(node[key]) == 0:
+                return []
+            if isinstance(node[key], dict):
+                return [node[key]]
+            return node[key]
+        return []
+    except TypeError:
+        return []

--- a/wagtail_wordpress_import/functions.py
+++ b/wagtail_wordpress_import/functions.py
@@ -48,3 +48,25 @@ def node_to_dict(node):
     if obj == {"nil": True}:
         return None
     return obj
+
+
+def snakecase_key(key):
+    """
+    Convert the key to snake_case by replacing ':' with '_'
+    and remove any leading '_'
+    This is so the keys are valid as Python kwargs and can be used to filter
+    the page models on on keys in the wp_post_meta which is a JSONField().
+    """
+    return (
+        str(key)  # some keys look like boolean types
+        .replace(":", "_")  # some keys contain ':'
+        .lstrip("_")  # some keys start with '_'
+    )
+
+
+def dict_to_list(node, key):
+    if key in node:
+        if isinstance(node[key], dict):
+            return [node[key]]
+        return node[key]
+    return []

--- a/wagtail_wordpress_import/functions.py
+++ b/wagtail_wordpress_import/functions.py
@@ -64,7 +64,7 @@ def snakecase_key(key):
     )
 
 
-def dict_to_list(node, key):
+def get_attr_as_list(node, key):
     if key in node:
         if isinstance(node[key], dict):
             return [node[key]]

--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -12,7 +12,11 @@ from django.utils.text import slugify
 from django.utils.timezone import make_aware
 from wagtail.core.models import Page
 from wagtail_wordpress_import.block_builder import BlockBuilder
-from wagtail_wordpress_import.functions import dict_to_list, node_to_dict, snakecase_key
+from wagtail_wordpress_import.functions import (
+    get_attr_as_list,
+    node_to_dict,
+    snakecase_key,
+)
 from wagtail_wordpress_import.importers.import_hooks import ItemsCache, TagsCache
 from wagtail_wordpress_import.importers.wordpress_defaults import (
     category_name_min_length,
@@ -446,7 +450,7 @@ class WordpressItem:
 
         cleaned = {}  # the final value to be returned
 
-        for item in dict_to_list(node, "wp:postmeta"):
+        for item in get_attr_as_list(node, "wp:postmeta"):
             cleaned[snakecase_key(item["wp:meta_key"])] = item["wp:meta_value"]
 
         # Remove wp:postmeta from the node so we don't use it's values again.

--- a/wagtail_wordpress_import/test/tests/test_functions.py
+++ b/wagtail_wordpress_import/test/tests/test_functions.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from wagtail_wordpress_import.functions import snakecase_key, dict_to_list
+
+
+class TestSnakeCaseKey(TestCase):
+    def test_snake_case_key_remove_colon(self):
+        self.assertEqual(snakecase_key("foo:bar"), "foo_bar")
+
+    def test_snake_case_key_remove_leading_underscore(self):
+        self.assertEqual(snakecase_key("_foo_bar"), "foo_bar")
+
+
+class TestDictToList(TestCase):
+    def test_dict_to_list_with_dict(self):
+        node = {"foo": {"bar": "baz"}}
+        self.assertEqual(dict_to_list(node, "foo"), [{"bar": "baz"}])
+
+    def test_dict_to_list_with_list(self):
+        node = {"foo": [{"foo": "bar"}, {"foo": "baz"}]}
+        self.assertEqual(dict_to_list(node, "foo"), [{"foo": "bar"}, {"foo": "baz"}])

--- a/wagtail_wordpress_import/test/tests/test_functions.py
+++ b/wagtail_wordpress_import/test/tests/test_functions.py
@@ -11,12 +11,30 @@ class TestSnakeCaseKey(TestCase):
 
 
 class TestDictToList(TestCase):
-    def test_dict_to_list_with_dict(self):
-        node = {"foo": {"bar": "baz"}}
-        self.assertEqual(get_attr_as_list(node, "foo"), [{"bar": "baz"}])
+    def test_default_with_string(self):
+        node = "foo"
+        self.assertEqual(get_attr_as_list(node, "foo"), [])
 
-    def test_dict_to_list_with_list(self):
-        node = {"foo": [{"foo": "bar"}, {"foo": "baz"}]}
-        self.assertEqual(
-            get_attr_as_list(node, "foo"), [{"foo": "bar"}, {"foo": "baz"}]
-        )
+    def test_default_with_dict(self):
+        node = {}
+        self.assertEqual(get_attr_as_list(node, "foo"), [])
+
+    def test_default_with_list(self):
+        node = []
+        self.assertEqual(get_attr_as_list(node, "foo"), [])
+
+    def test_default_list(self):
+        node = ["foo"]
+        self.assertEqual(get_attr_as_list(node, "foo"), [])
+
+    def test_default_empty_dict(self):
+        node = {"foo": {}}
+        self.assertEqual(get_attr_as_list(node, "foo"), [])
+
+    def test_with_expected_dict(self):
+        node = {"foo": {"bar": "baz", "baz": "bar"}}
+        self.assertEqual(get_attr_as_list(node, "foo"), [{"bar": "baz", "baz": "bar"}])
+
+    def test_with_expected_list(self):
+        node = {"foo": [{"bar": "baz", "baz": "bar"}]}
+        self.assertEqual(get_attr_as_list(node, "foo"), [{"bar": "baz", "baz": "bar"}])

--- a/wagtail_wordpress_import/test/tests/test_functions.py
+++ b/wagtail_wordpress_import/test/tests/test_functions.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from wagtail_wordpress_import.functions import snakecase_key, dict_to_list
+from wagtail_wordpress_import.functions import get_attr_as_list, snakecase_key
 
 
 class TestSnakeCaseKey(TestCase):
@@ -13,8 +13,10 @@ class TestSnakeCaseKey(TestCase):
 class TestDictToList(TestCase):
     def test_dict_to_list_with_dict(self):
         node = {"foo": {"bar": "baz"}}
-        self.assertEqual(dict_to_list(node, "foo"), [{"bar": "baz"}])
+        self.assertEqual(get_attr_as_list(node, "foo"), [{"bar": "baz"}])
 
     def test_dict_to_list_with_list(self):
         node = {"foo": [{"foo": "bar"}, {"foo": "baz"}]}
-        self.assertEqual(dict_to_list(node, "foo"), [{"foo": "bar"}, {"foo": "baz"}])
+        self.assertEqual(
+            get_attr_as_list(node, "foo"), [{"foo": "bar"}, {"foo": "baz"}]
+        )

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -327,4 +327,26 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
         # self.items_dict[4] = has no wp:post_meta items
         wordpress_item = WordpressItem(self.items_dict[4], self.logger)
         with self.assertRaises(KeyError):
-            post_meta = wordpress_item.clean_wp_post_meta()["wp:postmeta"]
+            wordpress_item.clean_wp_post_meta()["wp:postmeta"]
+
+    def test_items_dict_1_excluded_tags(self):
+        # self.items_dict[5] = has no wp:post_meta items
+        wordpress_item = WordpressItem(self.items_dict[1], self.logger)
+        with self.assertRaises(KeyError):
+            wordpress_item.clean_wp_post_meta()["wp:postmeta"]
+        with self.assertRaises(KeyError):
+            wordpress_item.clean_wp_post_meta()["content:encoded"]
+        with self.assertRaises(KeyError):
+            wordpress_item.clean_wp_post_meta()["dc:creator"]
+        with self.assertRaises(KeyError):
+            wordpress_item.clean_wp_post_meta()["wp:post_id"]
+
+    def test_items_dict_1_included_tags(self):
+        wordpress_item = WordpressItem(self.items_dict[1], self.logger)
+        self.assertTrue("title" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("dc_creator" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("guid" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("description" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("wp_post_id" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("wp_post_date" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("wp_post_meta" in wordpress_item.clean_wp_post_meta())

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -330,26 +330,28 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
 
     def test_items_dict_1_excluded_keys(self):
         wordpress_item = WordpressItem(self.items_dict[1], self.logger)
+        cleaned_postmeta = wordpress_item.clean_wp_post_meta()
         with self.assertRaises(KeyError):
-            wordpress_item.clean_wp_post_meta()["wp:postmeta"]
+            cleaned_postmeta["wp:postmeta"]
         with self.assertRaises(KeyError):
-            wordpress_item.clean_wp_post_meta()["wp_post_meta"]
+            cleaned_postmeta["wp_post_meta"]
         with self.assertRaises(KeyError):
-            wordpress_item.clean_wp_post_meta()["content:encoded"]
+            cleaned_postmeta["content:encoded"]
         with self.assertRaises(KeyError):
-            wordpress_item.clean_wp_post_meta()["dc:creator"]
+            cleaned_postmeta["dc:creator"]
         with self.assertRaises(KeyError):
-            wordpress_item.clean_wp_post_meta()["wp:post_id"]
+            cleaned_postmeta["wp:post_id"]
 
     def test_items_dict_1_included_keys(self):
         wordpress_item = WordpressItem(self.items_dict[1], self.logger)
-        self.assertTrue("title" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("dc_creator" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("guid" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("description" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("wp_post_id" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("wp_post_date" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("category" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("facebook_shares" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("pinterest_shares" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("twitter_shares" in wordpress_item.clean_wp_post_meta())
+        cleaned_postmeta = wordpress_item.clean_wp_post_meta()
+        self.assertTrue("title" in cleaned_postmeta)
+        self.assertTrue("dc_creator" in cleaned_postmeta)
+        self.assertTrue("guid" in cleaned_postmeta)
+        self.assertTrue("description" in cleaned_postmeta)
+        self.assertTrue("wp_post_id" in cleaned_postmeta)
+        self.assertTrue("wp_post_date" in cleaned_postmeta)
+        self.assertTrue("category" in cleaned_postmeta)
+        self.assertTrue("facebook_shares" in cleaned_postmeta)
+        self.assertTrue("pinterest_shares" in cleaned_postmeta)
+        self.assertTrue("twitter_shares" in cleaned_postmeta)

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -275,9 +275,8 @@ class WordpressImporterTestsYoastMetaDescriptions(TestCase):
 
 class WordpressImporterTestsCleanWpPostMeta(TestCase):
     """
-    This tests the post meta items retrieved from an XML file
-    are extracted correctly in WordpressItem().clean_wp_post_meta()
-    for various scenarios
+    This tests the wp_post_meta field contents after cleaning in
+    WordpressItem().clean_wp_post_meta()
     """
 
     fixtures = [
@@ -329,11 +328,12 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
         with self.assertRaises(KeyError):
             wordpress_item.clean_wp_post_meta()["wp:postmeta"]
 
-    def test_items_dict_1_excluded_tags(self):
-        # self.items_dict[5] = has no wp:post_meta items
+    def test_items_dict_1_excluded_keys(self):
         wordpress_item = WordpressItem(self.items_dict[1], self.logger)
         with self.assertRaises(KeyError):
             wordpress_item.clean_wp_post_meta()["wp:postmeta"]
+        with self.assertRaises(KeyError):
+            wordpress_item.clean_wp_post_meta()["wp_post_meta"]
         with self.assertRaises(KeyError):
             wordpress_item.clean_wp_post_meta()["content:encoded"]
         with self.assertRaises(KeyError):
@@ -341,7 +341,7 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
         with self.assertRaises(KeyError):
             wordpress_item.clean_wp_post_meta()["wp:post_id"]
 
-    def test_items_dict_1_included_tags(self):
+    def test_items_dict_1_included_keys(self):
         wordpress_item = WordpressItem(self.items_dict[1], self.logger)
         self.assertTrue("title" in wordpress_item.clean_wp_post_meta())
         self.assertTrue("dc_creator" in wordpress_item.clean_wp_post_meta())
@@ -349,4 +349,7 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
         self.assertTrue("description" in wordpress_item.clean_wp_post_meta())
         self.assertTrue("wp_post_id" in wordpress_item.clean_wp_post_meta())
         self.assertTrue("wp_post_date" in wordpress_item.clean_wp_post_meta())
-        self.assertTrue("wp_post_meta" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("category" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("facebook_shares" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("pinterest_shares" in wordpress_item.clean_wp_post_meta())
+        self.assertTrue("twitter_shares" in wordpress_item.clean_wp_post_meta())


### PR DESCRIPTION
# Fix wp_post_meta content

The last merge has caused an issue that wp_post_meta no longer contains required fields for import hooks.

I'm adding test to highlight the issue first then add in a fix for the clean_wp_post_meta() method.

The problem was that we altered clean_wp_post_meta() to only save `wp:postmeta ` data. We needed to also be saving all other data for an XML item tag. With the exception of `content:encoded`.

I've altered the clean_wp_post_meta() to also include some improvements to dealing with removing leading `_` and replacing `:` charachters.

Ticket URL:

---

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] This PR adds or updates documentation
