### PR TITLE
Add coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 include = wagtail_wordpress_import/*
 omit = */migrations/*,*/tests/*
+source=wagtail_wordpress_import
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,8 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/wagtail_wordpress_import
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-postgres
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ jobs:
           tox
         env:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-sqlite
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-postgres:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wagtail WordPress Import
 
+[![codecov](https://codecov.io/gh/torchbox/wagtail-wordpress-import/branch/main/graph/badge.svg?token=KFSTTxTGxZ)](https://codecov.io/gh/torchbox/wagtail-wordpress-import)
+
 A package for Wagtail CMS to import WordPress blog content from an XML file into Wagtail.
 
 - [Wagtail WordPress Import](#wagtail-wordpress-import)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="96" height="20" role="img" aria-label="coverage: 84%"><title>coverage: 84%</title><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="96" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#r)"><rect width="61" height="20" fill="#555"/><rect x="61" width="35" height="20" fill="#97ca00"/><rect width="96" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text><text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text><text aria-hidden="true" x="775" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">84%</text><text x="775" y="140" transform="scale(.1)" fill="#fff" textLength="250">84%</text></g></svg>
+
 # Wagtail WordPress Import
 
 A package for Wagtail CMS to import WordPress blog content from an XML file into Wagtail.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="96" height="20" role="img" aria-label="coverage: 84%"><title>coverage: 84%</title><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="96" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#r)"><rect width="61" height="20" fill="#555"/><rect x="61" width="35" height="20" fill="#97ca00"/><rect width="96" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text><text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text><text aria-hidden="true" x="775" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">84%</text><text x="775" y="140" transform="scale(.1)" fill="#fff" textLength="250">84%</text></g></svg>
-
 # Wagtail WordPress Import
 
 A package for Wagtail CMS to import WordPress blog content from an XML file into Wagtail.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ exclude = migrations,node_modules
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
-commands = coverage run testmanage.py test --deprecation all
+commands = 
+    coverage run testmanage.py test --deprecation all
+    coverage xml
 passenv = CI TRAVIS TRAVIS_*
 
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ exclude = migrations,node_modules
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run testmanage.py test --deprecation all
 passenv = CI TRAVIS TRAVIS_*
-deps = codecov
 
 basepython =
     python3.8: python3.8
@@ -22,6 +21,7 @@ basepython =
 
 deps =
     coverage
+    codecov
 
     django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<3.3

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ exclude = migrations,node_modules
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run testmanage.py test --deprecation all
+passenv = CI TRAVIS TRAVIS_*
+deps = codecov
+commands = codecov
 
 basepython =
     python3.8: python3.8
@@ -39,6 +42,7 @@ deps =
 
 setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_wordpress_import}
+
 
 [testenv:flake8]
 basepython=python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = coverage run testmanage.py test --deprecation all
 passenv = CI TRAVIS TRAVIS_*
 deps = codecov
-commands = codecov
 
 basepython =
     python3.8: python3.8


### PR DESCRIPTION
# Add Codecov

This adds codecov to display coverage test results using the example:
https://github.com/codecov/example-python

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/94

- Testing
    - [x] CI passes
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] This PR adds or updates documentation
