### PR TITLE
Fix Config overrides

### DIFF
--- a/docs/prefilters.md
+++ b/docs/prefilters.md
@@ -5,7 +5,8 @@
   - [How Pre-filters work](#how-pre-filters-work)
     - [Included Pre-Filters](#included-pre-filters)
     - [Pre-filter configuration](#pre-filter-configuration)
-    - [Add your own pre-filter options to an existing pre-filter](#add-your-own-pre-filter-options-to-an-existing-pre-filter)
+    - [Add your own pre-filter](#add-your-own-pre-filter)
+    - [Using custom options for bleach filter and transform inline styles filter](#using-custom-options-for-bleach-filter-and-transform-inline-styles-filter)
   - [Create your own pre-filter](#create-your-own-pre-filter)
 
 ## Why use pre-filters
@@ -113,13 +114,19 @@ Each pre-filter receives the output from the previous pre-filter, with the excep
 
 The output of the last pre-filter is passed to block builder to create the StreamField blocks JSON.
 
-### Add your own pre-filter options to an existing pre-filter
+### Add your own pre-filter
 
 Add `WAGTAIL_WORDPRESS_IMPORT_PREFILTERS` to your own settings file and include the new pre-filter. *It's possible to exclude a pre-filter by removing it from the list.*
+  
+```python
+{
+    "FUNCTION": "my_app.my_prefilters.my_filter",
+},
+```
 
-All filters can be passed an `OPTIONS` dict but it's currently only useful for the bleach filter.
+### Using custom options for bleach filter and transform inline styles filter
 
-For example: Using custom options in the bleach filter
+Filters can be passed an `OPTIONS` dict. It's currently only useful for the bleach filter and transform inline styles filter.
 
 ```python
 WAGTAIL_WORDPRESS_IMPORT_PREFILTERS = [
@@ -131,6 +138,14 @@ WAGTAIL_WORDPRESS_IMPORT_PREFILTERS = [
     },
     {
         "FUNCTION": "wagtail_wordpress_import.prefilters.transform_inline_styles",
+        "OPTIONS": {
+            "TRANSFORM_STYLES_MAPPING": [
+                (
+                    re.compile(r"font-weight:bold", re.IGNORECASE),
+                    "path.to.your.transform_function",
+                )
+            ],
+        },
     },
     {
         "FUNCTION": "wagtail_wordpress_import.prefilters.bleach_clean",
@@ -142,21 +157,17 @@ WAGTAIL_WORDPRESS_IMPORT_PREFILTERS = [
 ]
 ```
 
-Here `my-custom-tag` would be appended to the `ALLOWED_TAGS` in the bleach_filters and would not be escaped or removed from the final HTML
+Transform Styles Filter:
 
-To provide your own pre-filter add a new item to the configuration with the key FUNCTION and value is the dotted path to the function to be called.
+- `font-weight:normal` would be used by `filter_transform_inline_styles` to replace a HTML tag with a `b` tag if it has a style rule of `font-weight:bold`
 
-```python
-{
-    "FUNCTION": "my_app.my_prefilters.my_filter",
-},
-```
+Bleach filter:
 
-Add it at the position to match the running order you need. *It's possible to include an `OPTIONS` key for your own pre-filter which will be passed into your pre-filter method*
+- `my-custom-tag` would be appended to the `ALLOWED_TAGS` in the bleach_filters and would not be escaped or removed from the final HTML
 
 ## Create your own pre-filter
 
-You can find the provided pre-filters [here](wagtail_wordpress_import/prefilters) They are a good source of examples to create your own pre-filter.
+You can view the provided pre-filters [here](wagtail_wordpress_import/prefilters) They are a good source of examples to create your own pre-filter.
 
 To create your own pre-filter you need to create a module with a function in your app with the following signature:
 

--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -323,7 +323,9 @@ class WordpressItem:
         """
         cached_result = content
 
-        for filter in default_prefilters():
+        for filter in getattr(
+            settings, "WAGTAIL_WORDPRESS_IMPORT_PREFILTERS", default_prefilters()
+        ):
             function = import_string(filter["FUNCTION"])
             cached_result = function(cached_result, filter.get("OPTIONS"))
             if debug_enabled():

--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -22,7 +22,6 @@ from wagtail_wordpress_import.importers.wordpress_defaults import (
     category_name_min_length,
     category_plugin_enabled,
     debug_enabled,
-    default_prefilters,
     get_category_model,
     yoast_plugin_config,
     yoast_plugin_enabled,
@@ -30,6 +29,21 @@ from wagtail_wordpress_import.importers.wordpress_defaults import (
 from wagtail_wordpress_import.prefilters.linebreaks_wp_filter import (
     filter_linebreaks_wp,
 )
+
+DEFAULT_PREFILTERS = [
+    {
+        "FUNCTION": "wagtail_wordpress_import.prefilters.linebreaks_wp",
+    },
+    {
+        "FUNCTION": "wagtail_wordpress_import.prefilters.transform_shortcodes",
+    },
+    {
+        "FUNCTION": "wagtail_wordpress_import.prefilters.transform_inline_styles",
+    },
+    {
+        "FUNCTION": "wagtail_wordpress_import.prefilters.bleach_clean",
+    },
+]
 
 
 class WordpressImporter:
@@ -324,7 +338,7 @@ class WordpressItem:
         cached_result = content
 
         for filter in getattr(
-            settings, "WAGTAIL_WORDPRESS_IMPORT_PREFILTERS", default_prefilters()
+            settings, "WAGTAIL_WORDPRESS_IMPORT_PREFILTERS", DEFAULT_PREFILTERS
         ):
             function = import_string(filter["FUNCTION"])
             cached_result = function(cached_result, filter.get("OPTIONS"))

--- a/wagtail_wordpress_import/importers/wordpress_defaults.py
+++ b/wagtail_wordpress_import/importers/wordpress_defaults.py
@@ -1,23 +1,6 @@
 from django.conf import settings
 
 
-def default_prefilters():
-    return [
-        {
-            "FUNCTION": "wagtail_wordpress_import.prefilters.linebreaks_wp",
-        },
-        {
-            "FUNCTION": "wagtail_wordpress_import.prefilters.transform_shortcodes",
-        },
-        {
-            "FUNCTION": "wagtail_wordpress_import.prefilters.transform_inline_styles",
-        },
-        {
-            "FUNCTION": "wagtail_wordpress_import.prefilters.bleach_clean",
-        },
-    ]
-
-
 def debug_enabled():
     return getattr(settings, "WAGTAIL_WORDPRESS_IMPORT_DEBUG_ENABLED", True)
 

--- a/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
+++ b/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
@@ -1,42 +1,33 @@
-import re
 from django.conf import settings
 
 
 def transform_style_bold(soup, tag):
     """
-    replace the input tag name with `b`
-    and add the existing attrs["style"] to
-    the new tag
+    Replace the input tag name with `b` and remove style attr
     """
     new_tag = soup.new_tag("b")
-    new_tag.attrs["style"] = tag.attrs["style"]
     new_tag.string = tag.text
     tag.replace_with(new_tag)
 
 
 def transform_style_italic(soup, tag):
     """
-    replace the input tag name with `b`
-    and add the existing attrs["style"] to
-    the new tag
-
-    there are instances of <i> tag inside a <b> tag
-    preseve the <b> tag and add the <i> tag as a child
-    e.g. <b><i>text</i></b>
+    Replace the input tag name with `i` and remove style attr
     """
+    new_tag = soup.new_tag("i")
+    new_tag.string = tag.text
+    tag.append(new_tag)
 
-    if not tag.name == "b":
-        new_tag = soup.new_tag("i")
-        new_tag.string = tag.text
-        new_tag.attrs["style"] = tag.attrs["style"]
-        tag.replace_with(new_tag)
 
-    elif tag.name == "b":
-        new_tag = soup.new_tag("i")
-        new_tag.string = tag.text
-        new_tag.attrs["style"] = tag.attrs["style"]
-        tag.string = ""
-        tag.append(new_tag)
+def transform_style_bold_italic(soup, tag):
+    """
+    Replace the input tag name with `b` and a child of `i` and remove style attr
+    """
+    new_b_tag = soup.new_tag("b")
+    new_i_tag = soup.new_tag("i")
+    new_i_tag.string = tag.text
+    new_b_tag.append(new_i_tag)
+    tag.replace_with(new_b_tag)
 
 
 def transform_style_center(soup, tag):
@@ -87,50 +78,6 @@ def transform_float_right(soup, tag):
         tag.attrs["class"].append("float-right")
     else:
         tag.attrs["class"] = "float-right"
-
-
-def conf_styles_mapping():
-    """
-    Its intended that a developer can override TRANSFORM_STYLES_MAPPING
-    and provide their own style rules to match for by adding WAGTAIL_WORDPRESS_IMPORT_PREFILTERS
-    to their own settings
-
-    # example WAGTAIL_WORDPRESS_IMPORT_PREFILTERS config in your own settings is below
-
-    WAGTAIL_WORDPRESS_IMPORT_PREFILTERS = [
-        {"FUNCTION": "wagtail_wordpress_import.prefilters.linebreaks_wp_filter",},
-        {"FUNCTION": "wagtail_wordpress_import.prefilters.transform_styles_filter",},
-        {"FUNCTION": "prefilters.bleach_clean.clean",
-            "OPTIONS": {
-                "ADDITIONAL_ALLOWED_TAGS": ["h1", "h2", ...],
-                "ADDITIONAL_ALLOWED_ATTRIBUTES": ["style", "class", "data-attr", ...],
-                "ADDITIONAL_ALLOWED_STYLES": ["font-weight: bold", "font-style: italic", ...],
-            },
-        },
-    ]
-
-    The prefilters are run in the order of the list above.
-    If you don't need a filter to run you can remove it from the list.
-    If you need another filter to run you can include it in the list and will need
-    to provide the filter module in your own wagtail site
-
-    See the documentation in this repo for further help with creating filters
-    """
-    return [
-        (re.compile(r"font-weight:bold*", re.IGNORECASE), transform_style_bold),
-        (re.compile(r"font-style:italic*", re.IGNORECASE), transform_style_italic),
-        (
-            re.compile(
-                r"text-align:center*",
-                re.IGNORECASE,
-            ),
-            transform_style_center,
-        ),
-        (re.compile(r"text-align:left*", re.IGNORECASE), transform_style_left),
-        (re.compile(r"text-align:right*", re.IGNORECASE), transform_style_right),
-        (re.compile(r"float:left*", re.IGNORECASE), transform_float_left),
-        (re.compile(r"float:right*", re.IGNORECASE), transform_float_right),
-    ]
 
 
 def transform_html_tag_strong(soup, tag):

--- a/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
+++ b/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
@@ -116,25 +116,21 @@ def conf_styles_mapping():
 
     See the documentation in this repo for further help with creating filters
     """
-    return getattr(
-        settings,
-        "WAGTAIL_WORDPRESS_IMPORT_PREFILTERS",
-        [
-            (re.compile(r"font-weight:bold*", re.IGNORECASE), transform_style_bold),
-            (re.compile(r"font-style:italic*", re.IGNORECASE), transform_style_italic),
-            (
-                re.compile(
-                    r"text-align:center*",
-                    re.IGNORECASE,
-                ),
-                transform_style_center,
+    return [
+        (re.compile(r"font-weight:bold*", re.IGNORECASE), transform_style_bold),
+        (re.compile(r"font-style:italic*", re.IGNORECASE), transform_style_italic),
+        (
+            re.compile(
+                r"text-align:center*",
+                re.IGNORECASE,
             ),
-            (re.compile(r"text-align:left*", re.IGNORECASE), transform_style_left),
-            (re.compile(r"text-align:right*", re.IGNORECASE), transform_style_right),
-            (re.compile(r"float:left*", re.IGNORECASE), transform_float_left),
-            (re.compile(r"float:right*", re.IGNORECASE), transform_float_right),
-        ],
-    )
+            transform_style_center,
+        ),
+        (re.compile(r"text-align:left*", re.IGNORECASE), transform_style_left),
+        (re.compile(r"text-align:right*", re.IGNORECASE), transform_style_right),
+        (re.compile(r"float:left*", re.IGNORECASE), transform_float_left),
+        (re.compile(r"float:right*", re.IGNORECASE), transform_float_right),
+    ]
 
 
 def transform_html_tag_strong(soup, tag):

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -395,10 +395,10 @@ def foo_filter(content, options):
     return content, options
 
 
-@override_settings(WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[])
 class TestWordpressItemPrefilterOverride(TestCase):
     """Remove all pre-filters"""
 
+    @override_settings(WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[])
     def test_prefilter_content_no_filters(self):
         # The expected output is the same as the input because there
         # are no prefilters to apply to the content
@@ -408,16 +408,16 @@ class TestWordpressItemPrefilterOverride(TestCase):
         self.assertEqual(output, "foo bar baz")
 
 
-@override_settings(
-    WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[
-        {
-            "FUNCTION": "wagtail_wordpress_import.test.tests.test_wordpress_item.foo_filter"
-        }
-    ]
-)
 class TestWordpressItemPrefilterCustomOverride(TestCase):
     """Provide a custom pref-filter"""
 
+    @override_settings(
+        WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[
+            {
+                "FUNCTION": "wagtail_wordpress_import.test.tests.test_wordpress_item.foo_filter"
+            }
+        ]
+    )
     def test_custom_provided_prefilter(self):
         # The expected output is the same as the input because the applied filters
         # do nothing and return the same value.
@@ -428,17 +428,17 @@ class TestWordpressItemPrefilterCustomOverride(TestCase):
         self.assertEqual(output[1], None)
 
 
-@override_settings(
-    WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[
-        {
-            "FUNCTION": "wagtail_wordpress_import.test.tests.test_wordpress_item.foo_filter",
-            "OPTIONS": {"foo": "bar"},
-        }
-    ]
-)
 class TestWordpressItemPrefilterCustomOverrideWithOptions(TestCase):
     """Provide a custom pref-filter with options"""
 
+    @override_settings(
+        WAGTAIL_WORDPRESS_IMPORT_PREFILTERS=[
+            {
+                "FUNCTION": "wagtail_wordpress_import.test.tests.test_wordpress_item.foo_filter",
+                "OPTIONS": {"foo": "bar"},
+            }
+        ]
+    )
     def test_custom_provided_prefilter(self):
         # The expected output is the same as the input because the applied filters
         # do nothing and return the same value.

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -9,10 +9,10 @@ from example.models import Category
 from wagtail.core.models import Page
 from wagtail_wordpress_import.functions import node_to_dict
 from wagtail_wordpress_import.importers.wordpress import (
+    DEFAULT_PREFILTERS,
     WordpressImporter,
     WordpressItem,
 )
-from wagtail_wordpress_import.importers.wordpress_defaults import default_prefilters
 from wagtail_wordpress_import.logger import Logger
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
@@ -370,23 +370,22 @@ class TestWordpressItemPrefilterConfig(TestCase):
 
 class TestWordpressPrefilterDefaults(TestCase):
     def test_default_prefilters(self):
-        defaults = default_prefilters()
-        self.assertIsInstance(defaults, list)
-        self.assertTrue(len(defaults), 4)
+        self.assertIsInstance(DEFAULT_PREFILTERS, list)
+        self.assertTrue(len(DEFAULT_PREFILTERS), 4)
         self.assertEqual(
-            defaults[0]["FUNCTION"],
+            DEFAULT_PREFILTERS[0]["FUNCTION"],
             "wagtail_wordpress_import.prefilters.linebreaks_wp",
         )
         self.assertEqual(
-            defaults[1]["FUNCTION"],
+            DEFAULT_PREFILTERS[1]["FUNCTION"],
             "wagtail_wordpress_import.prefilters.transform_shortcodes",
         )
         self.assertEqual(
-            defaults[2]["FUNCTION"],
+            DEFAULT_PREFILTERS[2]["FUNCTION"],
             "wagtail_wordpress_import.prefilters.transform_inline_styles",
         )
         self.assertEqual(
-            defaults[3]["FUNCTION"],
+            DEFAULT_PREFILTERS[3]["FUNCTION"],
             "wagtail_wordpress_import.prefilters.bleach_clean",
         )
 

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -12,6 +12,7 @@ from wagtail_wordpress_import.importers.wordpress import (
     WordpressImporter,
     WordpressItem,
 )
+from wagtail_wordpress_import.importers.wordpress_defaults import default_prefilters
 from wagtail_wordpress_import.logger import Logger
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
@@ -355,3 +356,34 @@ class WordpressImporterTestsCleanWpPostMeta(TestCase):
         self.assertTrue("facebook_shares" in cleaned_postmeta)
         self.assertTrue("pinterest_shares" in cleaned_postmeta)
         self.assertTrue("twitter_shares" in cleaned_postmeta)
+
+
+class TestWordpressItemPrefilterConfig(TestCase):
+    def test_prefilter_content_default(self):
+        node = {"content:encoded": "foo bar baz"}
+        wordpress_item = WordpressItem(node, "")
+        output = wordpress_item.prefilter_content(wordpress_item.raw_body)
+        self.assertEqual(output, "<p>foo bar baz</p>\n")
+
+
+class TestWordpressPrefilterDefaults(TestCase):
+    def test_default_prefilters(self):
+        defaults = default_prefilters()
+        self.assertIsInstance(defaults, list)
+        self.assertTrue(len(defaults), 4)
+        self.assertEqual(
+            defaults[0]["FUNCTION"],
+            "wagtail_wordpress_import.prefilters.linebreaks_wp",
+        )
+        self.assertEqual(
+            defaults[1]["FUNCTION"],
+            "wagtail_wordpress_import.prefilters.transform_shortcodes",
+        )
+        self.assertEqual(
+            defaults[2]["FUNCTION"],
+            "wagtail_wordpress_import.prefilters.transform_inline_styles",
+        )
+        self.assertEqual(
+            defaults[3]["FUNCTION"],
+            "wagtail_wordpress_import.prefilters.bleach_clean",
+        )


### PR DESCRIPTION
# Fix the conf_styles_mapping() method

The current implementation of conf_styles_mapping() was incorrect and would return the value from settings of WAGTAIL_WORDPRESS_IMPORT_PREFILTERS. This is not the desired behaviour.

The desired behaviour for using an override for WAGTAIL_WORDPRESS_IMPORT_PREFILTERS is for a developer to provide a list of pre-filters to run on the HTML content.

If the config needs to be overridden or options passed in then as an example this is how the settings variable could be used:

```python
WAGTAIL_WORDPRESS_IMPORT_PREFILTERS = [
    {
        "FUNCTION": "wagtail_wordpress_import.prefilters.linebreaks_wp",
    },
    {
        "FUNCTION": "wagtail_wordpress_import.prefilters.transform_shortcodes",
    },
    {
        "FUNCTION": "wagtail_wordpress_import.prefilters.transform_inline_styles",
    },
    {
        "FUNCTION": "wagtail_wordpress_import.prefilters.bleach_clean",
        "OPTIONS": {
            "ADDITIONAL_ALLOWED_ATTRIBUTES": {
                "wagtail_block_anchor_image": "data-href",
                "wagtail_block_anchor_image": "data-src",
            },
        },
    },
]
```

Here we are passing in `OPTIONS` of `ADDITIONAL_ALLOWED_ATTRIBUTES`. The result is that bleach filter will have extra attributes on a specific HTML tag that are not removed.

Ticket URL: https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/107

---

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: the documentation is already included in prefilters.md
