### PR TITLE
Refactor date getters

### DIFF
--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -357,10 +357,16 @@ class WordpressItem:
         return self.clean_date(self.node["wp:post_date_gmt"].strip())
 
     def cleaned_last_published_at(self):
-        return self.clean_date(self.node["wp:post_modified_gmt"].strip())
+        try:
+            return self.clean_date(self.node["wp:post_modified_gmt"].strip())
+        except KeyError:
+            return self.cleaned_first_published_at()
 
     def cleaned_latest_revision_created_at(self):
-        return self.clean_date(self.node["wp:post_modified_gmt"].strip())
+        try:
+            return self.clean_date(self.node["wp:post_modified_gmt"].strip())
+        except KeyError:
+            return self.cleaned_first_published_at()
 
     def clean_date(self, value):
         """

--- a/wagtail_wordpress_import/test/fixtures/raw_xml.xml
+++ b/wagtail_wordpress_import/test/fixtures/raw_xml.xml
@@ -161,10 +161,8 @@ Nihil hic munitissimus habendi senatus locus, nihil horum?.&lt;/blockquote&gt;</
                 Nihil hic munitissimus habendi senatus locus, nihil horum?.&lt;/blockquote&gt;</content:encoded>
             <excerpt:encoded>Lorem ipsum dolor sit amet</excerpt:encoded>
             <wp:post_id>2</wp:post_id>
-            <wp:post_date>2010-07-13 12:16:46</wp:post_date>
-            <wp:post_date_gmt>2010-07-13 16:16:46</wp:post_date_gmt>
-            <wp:post_modified>2010-07-13 12:16:46</wp:post_modified>
-            <wp:post_modified_gmt>2010-07-13 16:16:46</wp:post_modified_gmt>
+            <wp:post_date>2010-01-13 12:00:00</wp:post_date>
+            <wp:post_date_gmt>2010-01-13 16:00:00</wp:post_date_gmt>
             <wp:comment_status>open</wp:comment_status>
             <wp:ping_status>open</wp:ping_status>
             <wp:post_name>item-two-title</wp:post_name>

--- a/wagtail_wordpress_import/test/tests/test_wordpress_importer.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_importer.py
@@ -137,6 +137,22 @@ class WordpressImporterTests(TestCase):
             "This page has a default description",
         )
 
+    def test_page_field_values_if_no_post_date_modified(self):
+        page = self.imported_pages.get(title="Item two title")
+        print(page)
+        self.assertEqual(str(page.first_published_at.date()), "2010-01-13")
+        self.assertEqual(str(page.first_published_at.time()), "16:00:00")
+        self.assertEqual(str(page.last_published_at.date()), "2010-01-13")
+        self.assertEqual(str(page.last_published_at.time()), "16:00:00")
+        self.assertEqual(
+            str(page.latest_revision_created_at.date()),
+            "2010-01-13",
+        )
+        self.assertEqual(
+            str(page.latest_revision_created_at.time()),
+            "16:00:00",
+        )
+
 
 IMPORTER_RUN_PARAMS_TEST_OVERRIDE_1 = {
     "app_for_pages": "example",


### PR DESCRIPTION
# An alternative XML to import from has missing date fields

if `wp:post_modified_gmt` is not available in the XML return `wp:post_date_gmt`

Issue: https://github.com/torchbox/wagtail-wordpress-import/issues/108

---

- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: the usage has not changed
