### PR TITLE
Upgrade lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "Django>=3.1,<3.3",
         "Wagtail>=2.14,<2.16",
-        "lxml==4.6.3",
+        "lxml>=4.6,<4.7",
         "bleach>=4.1,<4.2",
         "prettytable>=2.2,<2.3",
         "shortcodes>=5.1,<6.0",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "Django>=3.1,<3.3",
         "Wagtail>=2.14,<2.16",
-        "lxml>=4.6,<4.7",
+        "lxml>=4.7,<4.8",
         "bleach>=4.1,<4.2",
         "prettytable>=2.2,<2.3",
         "shortcodes>=5.1,<6.0",


### PR DESCRIPTION
# Upgrade lxml

Following a dependabot alter I have revised the version number for lxml.

Ticket URL: https://github.com/torchbox/wagtail-wordpress-import/security/dependabot/setup.py/lxml/open

In fact we had a fixed dependency in setup.py

---

- Testing
    - [x] CI passes
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: there is no change for the developer to consider.
