### PR TITLE
Support slash in file path in reduce command

### DIFF
--- a/wagtail_wordpress_import/management/commands/reduce_xml.py
+++ b/wagtail_wordpress_import/management/commands/reduce_xml.py
@@ -106,11 +106,12 @@ class Command(BaseCommand):
         self.stdout.write(f"\n[{status_list}]")
 
         # stats to file
-        f = open(f"stats-{file_path}.json", "w")
+        stats_filename = f"stats-{file_path.split('/')[-1]}.json"
+        f = open(stats_filename, "w")
         f.write(json.dumps(type_stats, indent=2))
 
         self.stdout.write(
-            self.style.SUCCESS(f"\nStats file is here: stats-{file_path}.json")
+            self.style.SUCCESS(f"\nStats file is here: {stats_filename}")
         )
 
         self.stdout.write(

--- a/wagtail_wordpress_import/management/commands/reduce_xml.py
+++ b/wagtail_wordpress_import/management/commands/reduce_xml.py
@@ -11,6 +11,11 @@ def register_all_namespaces(filename):
     for ns in namespaces:
         ET.register_namespace(ns, namespaces[ns])
 
+def generate_stats_file(file_path, type_stats):
+    stats_filename = f"stats-{file_path.split('/')[-1]}.json"
+    f = open(stats_filename, "w")
+    f.write(json.dumps(type_stats, indent=2))
+    return stats_filename
 
 class Command(BaseCommand):
 
@@ -106,10 +111,7 @@ class Command(BaseCommand):
         self.stdout.write(f"\n[{status_list}]")
 
         # stats to file
-        stats_filename = f"stats-{file_path.split('/')[-1]}.json"
-        f = open(stats_filename, "w")
-        f.write(json.dumps(type_stats, indent=2))
-
+        stats_filename = generate_stats_file(file_path, type_stats)
         self.stdout.write(
             self.style.SUCCESS(f"\nStats file is here: {stats_filename}")
         )

--- a/wagtail_wordpress_import/test/tests/test_commands.py
+++ b/wagtail_wordpress_import/test/tests/test_commands.py
@@ -3,7 +3,7 @@ import os
 from django.core.management import CommandError, call_command
 from django.test import TestCase, override_settings
 from wagtail.core.models import Page
-from wagtail_wordpress_import.management.commands.reduce_xml import Command as ReduceCmd
+from wagtail_wordpress_import.management.commands.reduce_xml import Command as ReduceCmd, generate_stats_file
 from wagtail_wordpress_import.xml_boilerplate import (
     build_xml_stream,
     generate_temporary_file,
@@ -153,3 +153,10 @@ class TestReduceCommand(TestCase):
             build_xml_stream(xml_tags_fragment="").read()
         )
         self.assertEqual(built_file, cmd.get_xml_file(built_file))
+
+    def test_xml_reduce_generate_stats(self):
+        stats_filename = generate_stats_file("/folder/test.xml", {})
+        self.assertEqual(stats_filename, "stats-test.xml")
+
+        stats_filename = generate_stats_file("test.xml", {})
+        self.assertEqual(stats_filename, "stats-test.xml")

--- a/wagtail_wordpress_import/test/tests/test_commands.py
+++ b/wagtail_wordpress_import/test/tests/test_commands.py
@@ -156,7 +156,7 @@ class TestReduceCommand(TestCase):
 
     def test_xml_reduce_generate_stats(self):
         stats_filename = generate_stats_file("/folder/test.xml", {})
-        self.assertEqual(stats_filename, "stats-test.xml")
+        self.assertEqual(stats_filename, "stats-test.xml.json")
 
         stats_filename = generate_stats_file("test.xml", {})
-        self.assertEqual(stats_filename, "stats-test.xml")
+        self.assertEqual(stats_filename, "stats-test.xml.json")


### PR DESCRIPTION
# Reduce commands fails when using a nested xml file path

I am using a docker setup locally, and have my `xml` file located in `/app/dump.xml` in the docker container.  
I am using the `reduce` command as : `python manage.py reduce_xml /app/dump.xml `
This causes the command to fail when writing the stats file as the command tries to write `f = open(f"stats-{file_path}.json", "w")` resulting in `'stats-/app/dump.xml.json'`

<details>
<summary>
Here is the full stacktrace
</summary>  
  
```python
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.8/site-packages/wagtail_wordpress_import/management/commands/reduce_xml.py", line 109, in handle
    f = open(f"stats-{file_path}.json", "w")
FileNotFoundError: [Errno 2] No such file or directory: 'stats-/app/dump.xml.json'
```
</details>

---


- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [ ] This PR adds or updates documentation
    - [x] Documentation changes are not necessary because they do not change the reduce command behavior/arguments
