### PR TITLE
Requests exception ordering

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -50,9 +50,6 @@ def fetch_url(src, allow_redirects=True):
     except requests.HTTPError:
         print(f"HTTPError: {src}")
         return None, False, None
-    except requests.RequestException:
-        print(f"RequestException: {src}")
-        return None, False, None
     except requests.ReadTimeout:
         print(f"ReadTimeout: {src}")
         return None, False, None
@@ -61,6 +58,9 @@ def fetch_url(src, allow_redirects=True):
         return None, False, None
     except requests.ConnectTimeout:
         print(f"ConnectTimeout: {src}")
+        return None, False, None
+    except requests.RequestException:
+        print(f"RequestException: {src}")
         return None, False, None
 
 


### PR DESCRIPTION
# Change the order of requests exceptions.

Changed following earlier MR comments: https://github.com/torchbox/wagtail-wordpress-import/issues/134

---

- Testing
    - [x] CI passes
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: there is no change to the use of the package
