### PR TITLE
Update settings documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ The package has been developed and tested with:
 
 Add a setting of `WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN` in your sites settings and set it to the the URL of the website that the images and documents will be imported from.
 
+The importer uses the [requests](https://docs.python-requests.org/en/latest/) library to download images and documents during the import process using the configuration in  `WAGTAIL_WORDPRESS_IMPORTER_REQUESTS_SETTINGS`. 
+
+If the default settings are not suitable for your import, you can add the settings below to your own site settings and override the values.
+
+```python
+# package default settings
+
+WAGTAIL_WORDPRESS_IMPORTER_REQUESTS_SETTINGS = {
+    "headers": { "User-Agent": "WagtailWordpressImporter" },
+    "timeout": 5,
+    "stream": True,
+    "allow_redirects": allow_redirects,
+}
+```
+
 ### First steps to configure your Wagtail app
 
 The import can be run on an existing or new site but you will need to perform some setup on your page models.


### PR DESCRIPTION
# WAGTAIL_WORDPRESS_IMPORTER_REQUESTS_SETTINGS

This adds WAGTAIL_WORDPRESS_IMPORTER_REQUESTS_SETTINGS override instructions to the documentation.

Issue: https://github.com/torchbox/wagtail-wordpress-import/issues/133

---

- Testing
    - [x] CI passes
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] This PR adds or updates documentation
