### PR TITLE
Allow image id to fail

### DIFF
--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -164,10 +164,14 @@ class CaptionHandler(BlockShortcodeHandler):
         else:
             link = ""
 
+        try:
+            image_id = image_file.id
+        except AttributeError:
+            image_id = None
         return {
             "type": "image",
             "value": {
-                "image": image_file.id,
+                "image": image_id,
                 "caption": caption,
                 "alignment": alignment,
                 "link": link,


### PR DESCRIPTION
# Allow image download without scheme and external domain

If images have an url like `//example.com/image.jpg`, the imported url does not care about the domain and prepend the wagtail domain, hence leading to a 404 when downloading the image

---


- Testing
    - [ ] CI passes
    - [ ] If necessary, tests are added for new or fixed behaviour
    - [ ] These changes do not reduce test coverage
- Documentation.
    - [ ] This PR adds or updates documentation
    - [ ] Documentation changes are not necessary because:
