### PR TITLE
Allow image src without scheme and with external domain

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -330,8 +330,9 @@ def get_absolute_src(src, domain_prefix=None):
     src = src.lstrip("/")
     url = urlparse(src)
 
-    if not url.scheme and "." in url.netloc:
-        return "https:{}".format(src)
+    if not url.netloc and domain_prefix:
+        domain_prefix_scheme = urlparse(domain_prefix).scheme
+        return "{}://{}".format(domain_prefix_scheme, url.path)
     elif not url.scheme and domain_prefix:
         return domain_prefix + "/" + src
     return src

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -328,10 +328,11 @@ def document_exists(name):
 
 def get_absolute_src(src, domain_prefix=None):
     src = src.lstrip("/")
+    url = urlparse(src)
 
-    if "." in urlparse(src).netloc:
+    if not url.scheme and "." in url.netloc:
         return "https:{}".format(src)
-    elif not urlparse(src).scheme and domain_prefix:
+    elif not url.scheme and domain_prefix:
         return domain_prefix + "/" + src
     return src
 

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -1,4 +1,5 @@
 import requests
+from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.files import File
@@ -327,7 +328,10 @@ def document_exists(name):
 
 def get_absolute_src(src, domain_prefix=None):
     src = src.lstrip("/")
-    if not src.startswith("http") and domain_prefix:
+
+    if "." in urlparse(src).netloc:
+        return "https:{}".format(src)
+    elif not urlparse(src).scheme and domain_prefix:
         return domain_prefix + "/" + src
     return src
 

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -329,12 +329,17 @@ def document_exists(name):
 def get_absolute_src(src, domain_prefix=None):
     src = src.lstrip("/")
     url = urlparse(src)
+    known_file_extensions = ["jpg", "jpeg", "gif", "png", "webp"]
 
-    if not url.netloc and domain_prefix:
-        domain_prefix_scheme = urlparse(domain_prefix).scheme
-        return "{}://{}".format(domain_prefix_scheme, url.path)
-    elif not url.scheme and domain_prefix:
-        return domain_prefix + "/" + src
+    if not url.scheme and domain_prefix:
+        first_url_part = url.path.split("/")[0]
+        if (
+            "." in first_url_part
+            and first_url_part.split(".")[1].lower() not in known_file_extensions
+        ):
+            return "{}://{}".format(urlparse(domain_prefix).scheme, url.path)
+        return "{}/{}".format(domain_prefix, src)
+
     return src
 
 

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -338,7 +338,7 @@ class TestBlockBuilderUtilityMethods(TestCase):
     def test_get_abolute_src_slashes_at_start(self):
         self.assertEqual(
             get_absolute_src("//folder/fakeimage.jpg", "http://www.example.com"),
-            "http://www.example.com/folder/fakeimage.jpg",
+            "http://example.com/folder/fakeimage.jpg",
         )
 
     def test_get_abolute_src_slashes_at_start_external_domain(self):

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -338,7 +338,7 @@ class TestBlockBuilderUtilityMethods(TestCase):
     def test_get_abolute_src_slashes_at_start(self):
         self.assertEqual(
             get_absolute_src("//folder/fakeimage.jpg", "http://www.example.com"),
-            "http://example.com/folder/fakeimage.jpg",
+            "http://www.example.com/folder/fakeimage.jpg",
         )
 
     def test_get_abolute_src_slashes_at_start_external_domain(self):

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -344,7 +344,7 @@ class TestBlockBuilderUtilityMethods(TestCase):
     def test_get_abolute_src_slashes_at_start_external_domain(self):
         self.assertEqual(
             get_absolute_src("//example.com/fakeimage.jpg", "http://www.example.com"),
-            "https://example.com/folder/fakeimage.jpg",
+            "https://example.com/fakeimage.jpg",
         )
 
     def test_get_alignment_class_align_left(self):

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -341,6 +341,12 @@ class TestBlockBuilderUtilityMethods(TestCase):
             "http://www.example.com/folder/fakeimage.jpg",
         )
 
+    def test_get_abolute_src_slashes_at_start_external_domain(self):
+        self.assertEqual(
+            get_absolute_src("//example.com/fakeimage.jpg", "http://www.example.com"),
+            "https://example.com/folder/fakeimage.jpg",
+        )
+
     def test_get_alignment_class_align_left(self):
         soup = get_soup(
             '<img src="fakeimage.jpg" alt="image alt" class="align-left" />',

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -343,8 +343,12 @@ class TestBlockBuilderUtilityMethods(TestCase):
 
     def test_get_abolute_src_slashes_at_start_external_domain(self):
         self.assertEqual(
-            get_absolute_src("//example.com/fakeimage.jpg", "http://www.example.com"),
+            get_absolute_src("//example.com/fakeimage.jpg", "https://www.example.com"),
             "https://example.com/fakeimage.jpg",
+        )
+        self.assertEqual(
+            get_absolute_src("//example.com/fakeimage.jpg", "http://www.example.com"),
+            "http://example.com/fakeimage.jpg",
         )
 
     def test_get_alignment_class_align_left(self):


### PR DESCRIPTION
## Description

If images have a src attribute like `//example.com/image.jpg`, the imported url does not care about the domain and prepend the wagtail domain, hence leading to a 404 when downloading the image

---


- Testing
    - [x] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because they do not change how the importer usage
