### PR TITLE
Fix/145

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
 from django.utils.module_loading import import_string
+from django.db.utils import IntegrityError
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
 
@@ -128,7 +129,10 @@ def get_or_save_image(src):
             retrieved_image = ImportedImage(
                 file=File(file=temp_image), title=image_file_name
             )
-            retrieved_image.save()
+            try:
+                retrieved_image.save()
+            except IntegrityError:
+                retrieved_image = None
             temp_image.close()
             return retrieved_image
         else:

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -19,6 +19,7 @@ from wagtail_wordpress_import.block_builder_defaults import (
     get_alignment_class,
     get_image_alt,
     get_image_file_name,
+    get_or_save_image,
     image_linker,
 )
 from wagtail_wordpress_import.test.tests.utility_functions import (
@@ -361,6 +362,20 @@ class TestBlockBuilderUtilityMethods(TestCase):
             "html.parser",
         ).find("img")
         self.assertEqual(get_alignment_class(soup), "fullwidth")
+
+    @responses.activate
+    def test_get_or_save_image_corrupted_file(self):
+        image_url = "http://example.com/no-image.jpg"
+        responses.add(
+            responses.GET,
+            image_url,
+            body=mock_image().read(),
+            status=200,
+            content_type="image/jpegs",
+        )
+
+        retrieved_image = get_or_save_image(image_url)
+        self.assertTrue(isinstance(retrieved_image, get_image_model()))
 
 
 class TestBlockBuilderFetchUrlRequests(TestCase):


### PR DESCRIPTION
# Fail silently if downloaded image is corrupted

Ticket URL: https://github.com/torchbox/wagtail-wordpress-import/issues/145

---

In some cases, the download image be corrupted, hence having a width of 0 pixels, and causing an integrity error when django attempts to save it in database.
  
I suggest returning None in this case. 
It could be worth adding

## TODO
- [ ] Log somewhere that this specific image was not imported
- [ ] Prevent this image from being downloaded again (as it can slow down next imports) 

---

- Testing
    - [ ] CI passes
    - [ ] If necessary, tests are added for new or fixed behaviour
    - [ ] These changes do not reduce test coverage
- Documentation.
    - [ ] This PR adds or updates documentation
    - [ ] Documentation changes are not necessary because:
