### PR TITLE
Category names that are numbers

### DIFF
--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -304,7 +304,7 @@ class WordpressImporter:
     def connect_page_categories(self, page, category_model, item):
         if "category" in item.keys():
             categories = [
-                category
+                str(category)
                 for category in item["category"]
                 if category and len(str(category)) > category_name_min_length()
             ]

--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -306,7 +306,7 @@ class WordpressImporter:
             categories = [
                 category
                 for category in item["category"]
-                if category and len(category) > category_name_min_length()
+                if category and len(str(category)) > category_name_min_length()
             ]
 
             page_categories = []

--- a/wagtail_wordpress_import/test/fixtures/raw_xml.xml
+++ b/wagtail_wordpress_import/test/fixtures/raw_xml.xml
@@ -98,6 +98,7 @@ Nihil hic munitissimus habendi senatus locus, nihil horum?.&lt;/blockquote&gt;</
             <category domain="category" nicename="blogging">Blogging</category>
             <category domain="category" nicename="life">Life</category>
             <category domain="category" nicename="a">A</category>
+            <category domain="category" nicename="2016">2016</category>
             <category domain="" nicename="an-empty-category-should-not-be-imported-or-linked"></category>
             <wp:postmeta>
                 <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -163,6 +163,7 @@ class WordpressItemImportTests(TestCase):
         self.assertEqual(3, categories.count())
         self.assertEqual(categories[0].name, "Blogging")
         self.assertEqual(categories[1].name, "Life")
+        self.assertEqual(categories[2].name, "2016")
 
     def test_page_two_has_categories(self):
         page_two = self.imported_pages.get(title="Item two title")

--- a/wagtail_wordpress_import/test/tests/test_wordpress_item.py
+++ b/wagtail_wordpress_import/test/tests/test_wordpress_item.py
@@ -155,12 +155,12 @@ class WordpressItemImportTests(TestCase):
 
     def test_category_snippets_are_saved(self):
         snippets = Category.objects.all()
-        self.assertEqual(len(snippets), 4)
+        self.assertEqual(len(snippets), 5)
 
     def test_page_one_has_categories(self):
         page_one = self.imported_pages.get(title="Item one title")
         categories = page_one.specific.categories.all()
-        self.assertEqual(2, categories.count())
+        self.assertEqual(3, categories.count())
         self.assertEqual(categories[0].name, "Blogging")
         self.assertEqual(categories[1].name, "Life")
 


### PR DESCRIPTION
# Avoid error when category names are numbers

If a category name is `2016` in the XML `pulldom` will preserve it as an integer type. As we check the length of the name it needs to be a string.

Issue: https://github.com/torchbox/wagtail-wordpress-import/issues/148

---

This adds a new category to test in the XML file for one of the items and passes the name through `str()` to convert the category name before the length is tested.

- Testing
    - [ ] CI passes
    - [x] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] Documentation changes are not necessary because: no changes are made to the package operation.
