### PR TITLE
Support wagtail 2.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,8 @@ jobs:
         django: ['3.1', '3.2']
         wagtail: ['2.14', '2.15', '2.16']
         exclude: 
-          - wagtail: ['2.15', '2.16']
+          - wagtail: '2.16'
             django: '3.1'
-            python: '3.8'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,8 @@ jobs:
         wagtail: ['2.14', '2.15', '2.16']
         postgres: ['10.8']
         exclude: 
-          - wagtail: ['2.15', '2.16']
+          - wagtail: '2.16'
             django: '3.1'
-            python: '3.8'
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
         python: ['3.8', '3.9']
         django: ['3.1', '3.2']
         wagtail: ['2.14', '2.15', '2.16']
+        exclude: 
+          - wagtail: ['2.15', '2.16']
+            django: '3.1'
+            python: '3.8'
 
     steps:
       - uses: actions/checkout@v2
@@ -47,6 +51,10 @@ jobs:
         django: ['3.1', '3.2']
         wagtail: ['2.14', '2.15', '2.16']
         postgres: ['10.8']
+        exclude: 
+          - wagtail: ['2.15', '2.16']
+            django: '3.1'
+            python: '3.8'
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python: ['3.8', '3.9']
         django: ['3.1', '3.2']
-        wagtail: ['2.14']
+        wagtail: ['2.14', '2.15', '2.16']
 
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
       matrix:
         python: ['3.8', '3.9']
         django: ['3.1', '3.2']
-        wagtail: ['2.14']
+        wagtail: ['2.14', '2.15', '2.16']
         postgres: ['10.8']
 
     services:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A package for Wagtail CMS to import WordPress blog content from an XML file into
 
 The package has been developed and tested with:
 
-- Wagtail: 2.14 and 2.15
+- Wagtail: from 2.14 to 2.16
 - Django: 3.1 and 3.2
 - Postgres and SQLite Databases
 

--- a/docs/long_description.md
+++ b/docs/long_description.md
@@ -12,7 +12,7 @@ A package for Wagtail CMS to import WordPress blog content from an XML file into
 
 The package has been developed and tested with:
 
-- Wagtail: 2.14 and 2.15
+- Wagtail: from 2.14 to 2.16
 - Django: 3.1 and 3.2
 - Postgres and SQLite Databases
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     install_requires=[
         "Django>=3.1,<3.3",
-        "Wagtail>=2.14,<2.16",
+        "Wagtail>=2.14,<2.17",
         "lxml>=4.7,<4.8",
         "bleach>=4.1,<4.2",
         "prettytable>=2.2,<2.3",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,master}-{sqlite,postgres}
+envlist = python{3.8,3.9}-django{3.1,3.2,master}-wagtail{2.14,2.15,2.16,master}-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -32,6 +32,7 @@ deps =
 
     wagtail2.14: wagtail>=2.14,<2.15
     wagtail2.15: wagtail>=2.15,<2.16
+    wagtail2.16: wagtail>=2.16,<2.17
     wagtailmaster: git+https://github.com/wagtail/wagtail.git
 
     lxml: lxml>=4.6,<4,7


### PR DESCRIPTION
# Support wagtail 2.16

Wagtail 2.16 is now out, this PR adds support for this new version.
  
**Note** : I added wagtail 2.15 and 2.16 to github actions as we currently only test with wagtail 2.14. 
Is there a reason these versions were not tested in the CI ?

  
---

- Testing
    - [x] CI passes
    - [x] These changes do not reduce test coverage
- Documentation.
    - [x] This PR adds or updates documentation