### PR TITLE
Reorder exception as some are not reachable

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -44,14 +44,11 @@ def fetch_url(src, allow_redirects=True):
         )
         status = True if response.status_code == 200 else False
         return response, status, response.headers.get("content-type")
+    except requests.ConnectTimeout:
+        print(f"ConnectTimeout: {src}")
+        return None, False, None
     except requests.ConnectionError:
         print(f"ConnectionError: {src}")
-        return None, False, None
-    except requests.HTTPError:
-        print(f"HTTPError: {src}")
-        return None, False, None
-    except requests.RequestException:
-        print(f"RequestException: {src}")
         return None, False, None
     except requests.ReadTimeout:
         print(f"ReadTimeout: {src}")
@@ -59,8 +56,11 @@ def fetch_url(src, allow_redirects=True):
     except requests.Timeout:
         print(f"Timeout: {src}")
         return None, False, None
-    except requests.ConnectTimeout:
-        print(f"ConnectTimeout: {src}")
+    except requests.HTTPError:
+        print(f"HTTPError: {src}")
+        return None, False, None
+    except requests.RequestException:
+        print(f"RequestException: {src}")
         return None, False, None
 
 


### PR DESCRIPTION
I am working on an importer for another CMS (Spip), and base some of it on `wagtail-wordpress-import`. 
I noticed (thanks to my linter) that some exceptions were not reachable in this try / except block. 

This PR fixes that :)


- Testing
    - [x] CI passes
    - [ ] If necessary, tests are added for new or fixed behaviour
    - [x] These changes do not reduce test coverage
- Documentation.
    - [ ] This PR adds or updates documentation
    - [x] Documentation changes are not necessary because these does neither touch to existing features nor business logic